### PR TITLE
Rydd opp i startfil og GUI-kjøring

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel�
 
 | Fil | Beskrivelse |
 | --- | ----------- |
-| `Bilagskontroll v1.py` | Startfil som åpner GUI‑applikasjonen |
+| `bilagskontroll.py` | Startfil som åpner GUI‑applikasjonen |
 | `gui.py`              | All GUI‑logikk og `App`‑klassen |
 | `helpers.py`          | Hjelpefunksjoner for tekst, tall og kolonnevalg |
 | `report.py`           | Generering av PDF‑rapport |

--- a/gui.py
+++ b/gui.py
@@ -640,5 +640,5 @@ class App(ctk.CTk):
 
         self._update_status_card_safe()
 
-if __name__ == "__main__":
-    App().mainloop()
+# if __name__ == "__main__":
+#     App().mainloop()


### PR DESCRIPTION
## Oppsummering
- Setter `bilagskontroll.py` som tydelig startfil i dokumentasjonen.
- Fjerner direkte kjøring av GUI-modulen ved å kommentere ut `if __name__ == "__main__"`.

## Testing
- `python -m py_compile bilagskontroll.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7e3da0448328a5d35c38e3418fca