### PR TITLE
Tøm felter for utvalg og år ved oppstart

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -74,6 +74,8 @@ class App(ctk.CTk):
         self.grid_columnconfigure(1, weight=1)
         self.grid_rowconfigure(0, weight=1)
         self.sidebar = build_sidebar(self)
+        self.sample_size_var.set("")
+        self.year_var.set("")
         self.main = build_main(self)
 
         self.bind("<Left>", lambda e: self.prev())


### PR DESCRIPTION
## Endringer
- Tømmer `sample_size_var` og `year_var` direkte etter oppretting av sidepanelet.

## Testing
- `python bilagskontroll.py` *(feilet: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9116153083288fa75364e62f01ca