### PR TITLE
Bruk ledger_rows i report_utils

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -1,0 +1,41 @@
+from reportlab.platypus import Table, TableStyle, Paragraph
+from reportlab.lib import colors
+from helpers import parse_amount, fmt_money
+from gui.ledger import ledger_rows
+
+
+def build_ledger_table(app, invoice_value: str, style_small):
+    rows = ledger_rows(app, invoice_value)
+    if not rows:
+        return Paragraph("Ingen bokføringslinjer for dette fakturanummeret.", style_small)
+    data = [["Kontonr", "Konto", "MVA", "MVA-beløp", "Beløp", "Postert av"]]
+    total = 0.0
+    for r in rows:
+        v = parse_amount(r["Beløp"])
+        total += v or 0.0
+        data.append([
+            r["Kontonr"],
+            r["Konto"],
+            r["MVA"],
+            r["MVA-beløp"],
+            r["Beløp"],
+            r["Postert av"],
+        ])
+    data.append(["", "", "", "Sum:", fmt_money(total), ""])
+    colw = [60, 200, 35, 70, 70, 88]
+    tbl = Table(data, colWidths=colw, repeatRows=1, hAlign="LEFT")
+    tbl.setStyle(
+        TableStyle([
+            ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, -1), 8),
+            ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("ALIGN", (4, 1), (5, -2), "RIGHT"),
+            ("ALIGN", (4, -1), (5, -1), "RIGHT"),
+            ("SPAN", (0, -1), (3, -1)),
+            ("BACKGROUND", (0, 1), (-1, -1), colors.whitesmoke),
+            ("BACKGROUND", (0, 2), (-1, 2), colors.white),
+        ])
+    )
+    return tbl


### PR DESCRIPTION
## Sammendrag
- Legg til ny modul `report_utils` med hjelpefunksjonen `build_ledger_table`
- Hent hovedboklinjer via `ledger_rows` i stedet for app-methode

## Testing
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac923f749083288879f4fab925fa6c