### PR TITLE
Fiks feil ved generering av PDF-rapport

### DIFF
--- a/report.py
+++ b/report.py
@@ -100,7 +100,8 @@ def export_pdf(app):
     flow.append(Spacer(1, 8))
 
     def ledger_table_for_invoice(invoice_value: str):
-        rows = app._ledger_rows(invoice_value)
+        from gui.ledger import ledger_rows
+        rows = ledger_rows(app, invoice_value)
         if not rows:
             return Paragraph("Ingen bokføringslinjer for dette fakturanummeret.", small)
         data = [["Kontonr", "Konto", "MVA", "MVA-beløp", "Beløp", "Postert av"]]


### PR DESCRIPTION
## Sammendrag
- Bruk `ledger_rows` fra `gui.ledger` i PDF-eksporten i stedet for en manglende metode på `App`
- Hindrer krasj når PDF-rapport genereres uten hovedbok

## Testing
- `python -m py_compile report.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac9473046c8328981bb61dff401dbf