### PR TITLE
Fiks sammensetting av statuslinjer i PDF-rapport

### DIFF
--- a/report.py
+++ b/report.py
@@ -128,10 +128,12 @@ def export_pdf(app):
         flow.append(Spacer(1, 6))
     flow.append(
         Paragraph(
-            "<b>Status</b>:<br/>"
-            f"Sum kontrollert: {fmt_money(sum_k)} kr<br/>"
-            f"Sum alle bilag: {fmt_money(sum_a)} kr<br/>"
-            f"% kontrollert: {fmt_pct(pct)}",
+            (
+                "<b>Status</b>:<br/>"
+                f"Sum kontrollert: {fmt_money(sum_k)} kr<br/>"
+                f"Sum alle bilag: {fmt_money(sum_a)} kr<br/>"
+                f"% kontrollert: {fmt_pct(pct)}"
+            ),
             body,
         )
     )


### PR DESCRIPTION
## Oppsummering
- Slår sammen statuslinjer i PDF-rapporten til ett tekstargument slik at `Paragraph` får korrekt input.

## Testing
- `python -m py_compile report.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acc749a5f48328b296d03d28765870