### PR TITLE
Deaktiver navigasjonsknapper på første og siste bilag

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -290,6 +290,13 @@ class App(ctk.CTk):
             self.ledger_sum.configure(text="Last gjerne også inn en hovedbok for å se bilagslinjene.")
             self.comment_box.delete("0.0","end")
 
+        if self.sample_df is None or len(self.sample_df) == 0:
+            self.btn_prev.configure(state="disabled")
+            self.btn_next.configure(state="disabled")
+        else:
+            self.btn_prev.configure(state="normal" if self.idx > 0 else "disabled")
+            self.btn_next.configure(state="normal" if self.idx < len(self.sample_df) - 1 else "disabled")
+
         self._update_status_card_safe()
 
 if __name__ == "__main__":

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -36,8 +36,10 @@ def build_main(app):
     ctk.CTkButton(btns, text="⛔ Ikke godkjent", fg_color="#e74c3c", hover_color="#cf4334",
                   command=lambda: app.set_decision_and_next("Ikke godkjent")).grid(row=0, column=1, padx=6, pady=6, sticky="ew")
     ctk.CTkButton(btns, text="🔗 Åpne i PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=6, pady=6, sticky="ew")
-    ctk.CTkButton(btns, text="⬅ Forrige", command=app.prev).grid(row=0, column=3, padx=6, pady=6, sticky="ew")
-    ctk.CTkButton(btns, text="➡ Neste", command=app.next).grid(row=0, column=4, padx=6, pady=6, sticky="ew")
+    app.btn_prev = ctk.CTkButton(btns, text="⬅ Forrige", command=app.prev)
+    app.btn_prev.grid(row=0, column=3, padx=6, pady=6, sticky="ew")
+    app.btn_next = ctk.CTkButton(btns, text="➡ Neste", command=app.next)
+    app.btn_next.grid(row=0, column=4, padx=6, pady=6, sticky="ew")
 
     paned = tk.PanedWindow(panel, orient="horizontal")
     paned.grid(row=2, column=0, sticky="nsew", padx=12, pady=(4, 6))


### PR DESCRIPTION
## Sammendrag
- Lagrer referanser til knappene for «Forrige» og «Neste»
- Deaktiverer navigasjonsknappene når man er på første eller siste bilag

## Testing
- `python -m py_compile gui/mainview.py gui/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68adf7196b148328b5401d22dec879c1