### PR TITLE
Fjern duplikat dato i PDF-rapport

### DIFF
--- a/report.py
+++ b/report.py
@@ -97,7 +97,6 @@ def export_pdf(app):
 
     flow = []
     flow.append(Paragraph("Bilagskontroll – Rapport", title))
-    flow.append(Paragraph(now.strftime("%d.%m.%Y %H:%M"), body))
     flow.append(Spacer(1, 4))
     try:
         kunde = to_str(app.kunde_var.get()) if hasattr(app, "kunde_var") else ""


### PR DESCRIPTION
## Sammendrag
- fjernar øvste dato og tid frå PDF-rapporten slik at tidspunktet berre visast i informasjonsboksen

## Testing
- `python -m py_compile report.py`


------
https://chatgpt.com/codex/tasks/task_e_68af2fb5ba78832894c2f5f11dc9cac7