### PR TITLE
Hindrer utvalg uten antall og år

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -173,10 +173,12 @@ class App(ctk.CTk):
         if self.df is None:
             messagebox.showinfo(APP_TITLE, "Velg Excel først."); return
         try:
-            n = max(1, min(int(self.sample_size_var.get()), len(self.df)))
+            n = int(self.sample_size_var.get())
             year = int(self.year_var.get())
         except Exception:
-            n, year = min(len(self.df), 10), datetime.now().year
+            messagebox.showinfo(APP_TITLE, "Oppgi antall og år.")
+            return
+        n = max(1, min(n, len(self.df)))
         try:
             self.sample_df = self.df.sample(n=n, random_state=year).reset_index(drop=True)
         except Exception as e:

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -59,8 +59,15 @@ def build_sidebar(app):
         validatecommand=(vcmd_year, "%P"),
     ).grid(row=1, column=1, padx=(8, 0), pady=(6, 0))
 
-    ctk.CTkButton(card, text="🎲 Lag utvalg", command=app.make_sample)\
-        .grid(row=6, column=0, padx=14, pady=(8, 6), sticky="ew")
+    app.sample_btn = ctk.CTkButton(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
+    app.sample_btn.grid(row=6, column=0, padx=14, pady=(8, 6), sticky="ew")
+
+    def _toggle_sample_btn(*_):
+        state = "normal" if app.sample_size_var.get() and app.year_var.get() else "disabled"
+        app.sample_btn.configure(state=state)
+
+    app.sample_size_var.trace_add("write", _toggle_sample_btn)
+    app.year_var.trace_add("write", _toggle_sample_btn)
 
     app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=ctk.CTkFont(size=16, weight="bold"))
     app.lbl_filecount.grid(row=7, column=0, padx=14, pady=(2, 2), sticky="w")


### PR DESCRIPTION
## Endringer
- Gjør knappen **Lag utvalg** utilgjengelig til både antall og år er fylt inn
- Avviser forsøk på å lage utvalg uten gyldige verdier

## Testing
- `python -m py_compile gui/sidebar.py gui/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68af333a5b64832882d5fb3a722c05b8