### PR TITLE
Legg til informasjonstekst om automatisk kundenavn

### DIFF
--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -99,6 +99,11 @@ def build_sidebar(app):
     ctk.CTkEntry(opp, textvariable=app.kundenr_var).grid(row=1, column=1, padx=(0,8), pady=(4,4), sticky="ew")
     ctk.CTkLabel(opp, text="Utført av").grid(row=2, column=0, padx=(8,8), pady=(4,8), sticky="w")
     ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(row=2, column=1, padx=(0,8), pady=(4,8), sticky="ew")
+    ctk.CTkLabel(
+        opp,
+        text="Kundenavn hentes automatisk fra excelfil",
+        font=ctk.CTkFont(size=12, slant="italic"),
+    ).grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="w")
 
     card.grid_rowconfigure(20, weight=1)
 


### PR DESCRIPTION
## Sammendrag
- viser kursiv tekst som forklarer at kundenavn hentes automatisk fra Excel

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b2aed6960c83289aafce443896a056