### PR TITLE
Unngå at kundenavn-teksten blir avkuttet i sidepanelet

### DIFF
--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -99,20 +99,16 @@ def build_sidebar(app):
     ctk.CTkEntry(opp, textvariable=app.kundenr_var).grid(row=1, column=1, padx=(0,8), pady=(4,4), sticky="ew")
     ctk.CTkLabel(opp, text="Utført av").grid(row=2, column=0, padx=(8,8), pady=(4,8), sticky="w")
     ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(row=2, column=1, padx=(0,8), pady=(4,8), sticky="ew")
-    info_lbl = ctk.CTkLabel(
+    info_txt = ctk.CTkTextbox(
         opp,
-        text="Kundenavn hentes automatisk fra excelfil",
-        font=ctk.CTkFont(size=12, slant="italic"),
-        anchor="w",
-        justify="left",
+        width=0,
+        height=32,
+        fg_color="transparent",
+        border_width=0,
     )
-    info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
-
-    def _update_info_wrap(event):
-        """Tilpass linjebryting til etikettens fulle bredde."""
-        info_lbl.configure(wraplength=event.width)
-
-    info_lbl.bind("<Configure>", _update_info_wrap)
+    info_txt.insert("1.0", "Kundenavn hentes automatisk fra excelfil")
+    info_txt.configure(state="disabled", wrap="word")
+    info_txt.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
     card.grid_rowconfigure(20, weight=1)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -109,8 +109,9 @@ def build_sidebar(app):
     info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
     def _update_info_wrap(event):
-        """Tilpass linjebryting til etikettens faktiske bredde."""
-        info_lbl.configure(wraplength=event.width)
+        """Tilpass linjebryting til etikettens faktiske bredde med margin."""
+        wrap_len = max(event.width - 16, 0)
+        info_lbl.configure(wraplength=wrap_len)
 
     info_lbl.bind("<Configure>", _update_info_wrap)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -91,7 +91,7 @@ def build_sidebar(app):
     app.kunde_entry = ctk.CTkEntry(
         opp,
         textvariable=app.kunde_var,
-        placeholder_text="Hentes automatisk..",
+        placeholder_text="Hentes automatisk",
         state="disabled",
     )
     app.kunde_entry.grid(row=0, column=1, padx=(0,8), pady=(8,4), sticky="ew")
@@ -101,7 +101,7 @@ def build_sidebar(app):
     ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(row=2, column=1, padx=(0,8), pady=(4,8), sticky="ew")
     info_lbl = ctk.CTkLabel(
         opp,
-        text="Kundenavn hentes automatisk fra excelfil",
+        text="Kundenavn hentes automatisk",
         font=ctk.CTkFont(size=12, slant="italic"),
         anchor="w",
         justify="left",

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -99,14 +99,19 @@ def build_sidebar(app):
     ctk.CTkEntry(opp, textvariable=app.kundenr_var).grid(row=1, column=1, padx=(0,8), pady=(4,4), sticky="ew")
     ctk.CTkLabel(opp, text="Utført av").grid(row=2, column=0, padx=(8,8), pady=(4,8), sticky="w")
     ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(row=2, column=1, padx=(0,8), pady=(4,8), sticky="ew")
-    ctk.CTkLabel(
+    info_lbl = ctk.CTkLabel(
         opp,
         text="Kundenavn hentes automatisk fra excelfil",
         font=ctk.CTkFont(size=12, slant="italic"),
         anchor="w",
         justify="left",
-        wraplength=260,
-    ).grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
+    )
+    info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
+
+    def _update_info_wrap(event):
+        info_lbl.configure(wraplength=info_lbl.winfo_width())
+
+    info_lbl.bind("<Configure>", _update_info_wrap)
 
     card.grid_rowconfigure(20, weight=1)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -108,12 +108,11 @@ def build_sidebar(app):
     )
     info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
-    def _update_info_wrap(event=None):
-        # Juster linjebryting basert på bredden til foreldrerammen
-        info_lbl.configure(wraplength=max(opp.winfo_width() - 24, 0))
+    def _update_info_wrap(event):
+        """Tilpass linjebryting til etikettens faktiske bredde."""
+        info_lbl.configure(wraplength=event.width)
 
-    opp.bind("<Configure>", _update_info_wrap)
-    _update_info_wrap()
+    info_lbl.bind("<Configure>", _update_info_wrap)
 
     card.grid_rowconfigure(20, weight=1)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -109,7 +109,8 @@ def build_sidebar(app):
     info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
     def _update_info_wrap(event):
-        info_lbl.configure(wraplength=event.width - 4)
+        # Trekk fra litt ekstra margin for å unngå at teksten klippes i høyre kant
+        info_lbl.configure(wraplength=max(event.width - 16, 0))
 
     info_lbl.bind("<Configure>", _update_info_wrap)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -109,9 +109,8 @@ def build_sidebar(app):
     info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
     def _update_info_wrap(event):
-        """Tilpass linjebryting til etikettens faktiske bredde med margin."""
-        wrap_len = max(event.width - 16, 0)
-        info_lbl.configure(wraplength=wrap_len)
+        """Tilpass linjebryting til etikettens fulle bredde."""
+        info_lbl.configure(wraplength=event.width)
 
     info_lbl.bind("<Configure>", _update_info_wrap)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -108,11 +108,12 @@ def build_sidebar(app):
     )
     info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
-    def _update_info_wrap(event):
-        # Trekk fra litt ekstra margin for å unngå at teksten klippes i høyre kant
-        info_lbl.configure(wraplength=max(event.width - 16, 0))
+    def _update_info_wrap(event=None):
+        # Juster linjebryting basert på bredden til foreldrerammen
+        info_lbl.configure(wraplength=max(opp.winfo_width() - 24, 0))
 
-    info_lbl.bind("<Configure>", _update_info_wrap)
+    opp.bind("<Configure>", _update_info_wrap)
+    _update_info_wrap()
 
     card.grid_rowconfigure(20, weight=1)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -99,16 +99,15 @@ def build_sidebar(app):
     ctk.CTkEntry(opp, textvariable=app.kundenr_var).grid(row=1, column=1, padx=(0,8), pady=(4,4), sticky="ew")
     ctk.CTkLabel(opp, text="Utført av").grid(row=2, column=0, padx=(8,8), pady=(4,8), sticky="w")
     ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(row=2, column=1, padx=(0,8), pady=(4,8), sticky="ew")
-    info_txt = ctk.CTkTextbox(
+    info_lbl = ctk.CTkLabel(
         opp,
-        width=0,
-        height=32,
-        fg_color="transparent",
-        border_width=0,
+        text="Kundenavn hentes automatisk fra excelfil",
+        font=ctk.CTkFont(size=12, slant="italic"),
+        anchor="w",
+        justify="left",
+        wraplength=240,
     )
-    info_txt.insert("1.0", "Kundenavn hentes automatisk fra excelfil")
-    info_txt.configure(state="disabled", wrap="word")
-    info_txt.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
+    info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="w")
 
     card.grid_rowconfigure(20, weight=1)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -103,7 +103,10 @@ def build_sidebar(app):
         opp,
         text="Kundenavn hentes automatisk fra excelfil",
         font=ctk.CTkFont(size=12, slant="italic"),
-    ).grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="w")
+        anchor="w",
+        justify="left",
+        wraplength=260,
+    ).grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
     card.grid_rowconfigure(20, weight=1)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -109,7 +109,7 @@ def build_sidebar(app):
     info_lbl.grid(row=3, column=0, columnspan=2, padx=(8,8), pady=(0,8), sticky="ew")
 
     def _update_info_wrap(event):
-        info_lbl.configure(wraplength=info_lbl.winfo_width())
+        info_lbl.configure(wraplength=event.width - 4)
 
     info_lbl.bind("<Configure>", _update_info_wrap)
 


### PR DESCRIPTION
## Sammendrag
- Sørger for at hintet om automatisk kundenavn vises fullt ut i sidepanelet.

## Testing
- `python -m py_compile gui/sidebar.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2b18c5c2483288f0928812688a55a