### PR TITLE
Utsett innlasting av logo og håndter manglende bilder

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -68,22 +68,6 @@ class App(ctk.CTk):
         self.gl_postedby_col = None
 
         self.logo_img = None
-        try:
-            from PIL import Image
-            img_light = Image.open(resource_path("icons/bilagskontroll_logo_256.png"))
-            try:
-                img_dark = Image.open(resource_path("icons/bilagskontroll_icon_darkmode_256.png"))
-            except Exception:
-                img_dark = None
-            try:
-                if img_dark:
-                    self.logo_img = ctk.CTkImage(light_image=img_light, dark_image=img_dark, size=(32, 32))
-                else:
-                    self.logo_img = ctk.CTkImage(light_image=img_light, size=(32, 32))
-            except TypeError:
-                self.logo_img = ctk.CTkImage(img_light, size=(32, 32))
-        except Exception:
-            pass
 
         self.grid_columnconfigure(0, weight=0)
         self.grid_columnconfigure(1, weight=1)
@@ -97,6 +81,7 @@ class App(ctk.CTk):
         self.bind("<Right>", lambda e: self.next())
         self.bind("<Control-o>", lambda e: self.open_in_po())
         self.render()
+        self.after(0, self.load_logo_images)
 
     # Theme
     def _switch_theme(self, mode):
@@ -122,6 +107,27 @@ class App(ctk.CTk):
             self.iconphoto(False, self.app_icon_img)
         except Exception:
             pass
+
+    def load_logo_images(self):
+        try:
+            from PIL import Image
+            img_light = Image.open(resource_path("icons/bilagskontroll_logo_256.png"))
+            try:
+                img_dark = Image.open(resource_path("icons/bilagskontroll_icon_darkmode_256.png"))
+            except Exception:
+                img_dark = None
+            try:
+                if img_dark:
+                    self.logo_img = ctk.CTkImage(light_image=img_light, dark_image=img_dark, size=(32, 32))
+                else:
+                    self.logo_img = ctk.CTkImage(light_image=img_light, size=(32, 32))
+            except TypeError:
+                self.logo_img = ctk.CTkImage(img_light, size=(32, 32))
+        except Exception:
+            self.logo_img = None
+            return
+        if hasattr(self, "bottom_frame"):
+            ctk.CTkLabel(self.bottom_frame, text="", image=self.logo_img).pack(side="right", padx=(8,0))
 
     # Files
     def choose_file(self):

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -95,8 +95,7 @@ def build_main(app):
 
     bottom = ctk.CTkFrame(panel)
     bottom.grid(row=3, column=0, sticky="ew", padx=12, pady=(0, 0))
+    app.bottom_frame = bottom
     ctk.CTkButton(bottom, text="📄 Eksporter PDF rapport", command=lambda: report.export_pdf(app)).pack(side="left")
     ctk.CTkLabel(bottom, text="").pack(side="left", expand=True, fill="x")
-    if app.logo_img:
-        ctk.CTkLabel(bottom, text="", image=app.logo_img).pack(side="right", padx=(8,0))
     return panel


### PR DESCRIPTION
## Sammendrag
- Flyttet PIL-import og bildeåpning til `load_logo_images` som kjøres etter at GUI-et vises.
- Lagrer referanse til bunnrammen og legger til logo når bildet er tilgjengelig.
- Ignorerer manglende bilder slik at programmet fortsatt fungerer uten logo.

## Testing
- `python -m py_compile gui/__init__.py gui/mainview.py`
- `pytest` (ingen tester funnet)


------
https://chatgpt.com/codex/tasks/task_e_68b544462e608328a7a11dede43062bb