### PR TITLE
Last PDF-moduler ved behov for raskere oppstart

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -26,7 +26,6 @@ from data_utils import (
     calc_sum_kontrollert,
     calc_sum_net_all,
 )
-import report
 from .sidebar import build_sidebar
 from .mainview import build_main
 from .ledger import apply_treeview_theme, update_treeview_stripes, populate_ledger_table

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,7 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
 import customtkinter as ctk
-import report
 from .ledger import LEDGER_COLS, apply_treeview_theme, update_treeview_stripes
 
 
@@ -96,6 +95,11 @@ def build_main(app):
     bottom = ctk.CTkFrame(panel)
     bottom.grid(row=3, column=0, sticky="ew", padx=12, pady=(0, 0))
     app.bottom_frame = bottom
-    ctk.CTkButton(bottom, text="📄 Eksporter PDF rapport", command=lambda: report.export_pdf(app)).pack(side="left")
+
+    def _export_pdf():
+        from report import export_pdf
+        export_pdf(app)
+
+    ctk.CTkButton(bottom, text="📄 Eksporter PDF rapport", command=_export_pdf).pack(side="left")
     ctk.CTkLabel(bottom, text="").pack(side="left", expand=True, fill="x")
     return panel

--- a/report.py
+++ b/report.py
@@ -11,7 +11,6 @@ from helpers import (
     format_number_with_thousands,
 )
 
-from report_utils import build_ledger_table
 from data_utils import calc_sum_kontrollert, calc_sum_net_all
 
 
@@ -35,6 +34,7 @@ def export_pdf(app):
         app._show_inline("Manglende modul: reportlab (py -m pip install reportlab)", ok=False)
         return
 
+    from report_utils import build_ledger_table
     now = datetime.now()
     save = filedialog.asksaveasfilename(
         title="Lagre PDF-rapport",

--- a/report_utils.py
+++ b/report_utils.py
@@ -1,10 +1,10 @@
-from reportlab.platypus import Table, TableStyle, Paragraph
-from reportlab.lib import colors
 from helpers import parse_amount, fmt_money
 from gui.ledger import ledger_rows
 
 
 def build_ledger_table(app, invoice_value: str, style_small):
+    from reportlab.platypus import Table, TableStyle, Paragraph
+    from reportlab.lib import colors
     rows = ledger_rows(app, invoice_value)
     if not rows:
         return Paragraph("Ingen bokføringslinjer for dette fakturanummeret.", style_small)


### PR DESCRIPTION
## Sammendrag
- Forsinker lasting av PDF-relaterte moduler til eksportknappen trykkes for å korte ned oppstartstiden.
- Flytter import av reportlab til funksjonsnivå for å unngå tung oppstart.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` (ingen tester funnet)


------
https://chatgpt.com/codex/tasks/task_e_68b71b4e395483289fc76ecffba67b38