### PR TITLE
Legg til logging av hovedhendelser

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Optional, List
 
-from helpers import parse_amount
+from helpers import parse_amount, logger
 
 
 FALLBACK_NET_COLUMNS: List[str] = [
@@ -24,12 +24,14 @@ def _pd():
 
 def load_invoice_df(path: str, header_idx: int = 4) -> pd.DataFrame:
     """Leser fakturalisten fra Excel."""
+    logger.info(f"Laster fakturaliste fra {path}")
     pd = _pd()
     return pd.read_excel(path, engine="openpyxl", header=header_idx)
 
 
 def load_gl_df(path: str) -> pd.DataFrame:
     """Leser hovedboken fra Excel."""
+    logger.info(f"Laster hovedbok fra {path}")
     pd = _pd()
     gl = pd.read_excel(path, engine="openpyxl", header=0)
     if sum(str(c).lower().startswith("unnamed") for c in gl.columns) > len(gl.columns) / 2:
@@ -45,6 +47,7 @@ def extract_customer_from_invoice_file(path: str) -> Optional[str]:
       - Søk etter mønster "Kunde: <navn>" eller "Customer: <navn>" i rad 2
       - Hvis ikke funn, velg lengste ikke-numeriske tekstcelle i rad 2
     """
+    logger.info(f"Henter kundenavn fra {path}")
     try:
         pd = _pd()
         raw = pd.read_excel(path, engine="openpyxl", header=None, nrows=2)

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -18,6 +18,7 @@ from helpers import (
     guess_col,
     guess_net_amount_col,
     fmt_pct,
+    logger,
 )
 from .sidebar import build_sidebar
 from .mainview import build_main
@@ -143,6 +144,7 @@ class App(ctk.CTk):
         path = self.file_path_var.get()
         if not path:
             return
+        logger.info(f"Laster fakturaliste fra {path}")
         header_idx = 4
         big = os.path.getsize(path) > 5 * 1024 * 1024
         if big and hasattr(self, "inline_status"):
@@ -184,6 +186,7 @@ class App(ctk.CTk):
         path = self.gl_path_var.get()
         if not path:
             return
+        logger.info(f"Laster hovedbok fra {path}")
         big = os.path.getsize(path) > 5 * 1024 * 1024
         if big and hasattr(self, "inline_status"):
             self.inline_status.configure(text="laster inn fil...")
@@ -227,6 +230,7 @@ class App(ctk.CTk):
             messagebox.showinfo(APP_TITLE, "Oppgi antall og år.")
             return
         n = max(1, min(n, len(self.df)))
+        logger.info(f"Trekker utvalg på {n} bilag for år {year}")
         try:
             self.sample_df = self.df.sample(n=n, random_state=year).reset_index(drop=True)
         except Exception as e:

--- a/helpers.py
+++ b/helpers.py
@@ -2,6 +2,14 @@
 import os
 import re
 import sys
+import logging
+
+logger = logging.getLogger("bilagskontroll")
+if not logger.handlers:
+    handler = logging.FileHandler("bilagskontroll.log", encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 def _pd():
     import pandas as pd

--- a/report.py
+++ b/report.py
@@ -9,6 +9,7 @@ from helpers import (
     fmt_money,
     fmt_pct,
     format_number_with_thousands,
+    logger,
 )
 
 from data_utils import calc_sum_kontrollert, calc_sum_net_all
@@ -43,6 +44,7 @@ def export_pdf(app):
         initialfile=f"bilagskontroll_{now.strftime('%Y%m%d_%H%M%S')}.pdf",
     )
     if not save:
+        logger.info("PDF-eksport avbrutt")
         app._show_inline("Avbrutt", ok=False)
         return
 
@@ -268,6 +270,7 @@ def export_pdf(app):
     )
     try:
         doc.build(flow)
+        logger.info(f"PDF-rapport lagret til {save}")
         app._show_inline(f"Lagret PDF: {os.path.basename(save)}", ok=True)
     except Exception as e:
         app._show_inline(f"Feil ved PDF-generering: {e}", ok=False)


### PR DESCRIPTION
## Sammendrag
- Konfigurerer en filbasert logger for **bilagskontroll** på INFO-nivå.
- Logger innlasting av Excel-filer, utvalgstrekk og eksport av PDF-rapport.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b724e1c328832882faadb00a1e68be