### PR TITLE
Legg til dra-og-slipp av filer via tkinterdnd2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bilagskontroll v1 er et skrivebordverktøy for å kontrollere leverandørbilag. Programmet gir et grafisk brukergrensesnitt for å trekke tilfeldige bilagsutvalg, gjennomgå hvert bilag og generere en rapport.
 
-Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel‑data, `customtkinter` for et moderne og responsivt grensesnitt og `reportlab` for å lage PDF‑rapporter.
+Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel‑data, `customtkinter` for et moderne og responsivt grensesnitt, `tkinterdnd2` for dra‑og‑slipp av filer og `reportlab` for å lage PDF‑rapporter.
 
 ## Struktur
 
@@ -35,6 +35,7 @@ Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel�
 - Python 3.x
 - [pandas](https://pypi.org/project/pandas/) – leser og håndterer Excel‑data
 - [customtkinter](https://pypi.org/project/customtkinter/) – gir et moderne brukergrensesnitt
+- [tkinterdnd2](https://pypi.org/project/tkinterdnd2/) – muliggjør dra‑og‑slipp av filer
 - [reportlab](https://pypi.org/project/reportlab/) – genererer PDF‑rapporten
 
 ## Installasjon
@@ -42,7 +43,7 @@ Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel�
 ```bash
 python -m venv venv
 source venv/bin/activate  # venv\Scripts\activate på Windows
-pip install pandas customtkinter reportlab
+pip install pandas customtkinter tkinterdnd2 reportlab
 ```
 
 ## Bruk

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -6,6 +6,7 @@ import os
 import tkinter as tk
 import customtkinter as ctk
 from tkinter import filedialog, messagebox
+from tkinterdnd2 import DND_FILES, TkinterDnD
 
 
 from helpers import (
@@ -27,9 +28,10 @@ APP_TITLE = "Bilagskontroll v1"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 
 # ----------------- App -----------------
-class App(ctk.CTk):
+class App(TkinterDnD.Tk, ctk.CTk):
     def __init__(self):
-        super().__init__()
+        TkinterDnD.Tk.__init__(self)
+        ctk.CTk.__init__(self)
         ctk.set_appearance_mode("system")
         ctk.set_default_color_theme("blue")
         self.title(APP_TITLE)
@@ -69,6 +71,11 @@ class App(ctk.CTk):
         self.sample_size_var.set("")
         self.year_var.set("")
         self.main = build_main(self)
+
+        self.drop_target_register(DND_FILES)
+        self.dnd_bind("<<Drop>>", self._on_file_drop)
+        self.gl_path_lbl.drop_target_register(DND_FILES)
+        self.gl_path_lbl.dnd_bind("<<Drop>>", self._on_gl_drop)
 
         self.bind("<Left>", lambda e: self.prev())
         self.bind("<Right>", lambda e: self.next())
@@ -136,6 +143,18 @@ class App(ctk.CTk):
         if not p: return
         self.gl_path_var.set(p)
         self._load_gl_excel()
+
+    def _on_file_drop(self, event):
+        files = self.tk.splitlist(event.data)
+        if files:
+            self.file_path_var.set(files[0])
+            self._load_excel()
+
+    def _on_gl_drop(self, event):
+        files = self.tk.splitlist(event.data)
+        if files:
+            self.gl_path_var.set(files[0])
+            self._load_gl_excel()
 
     # Read
     def _load_excel(self):

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -12,14 +12,14 @@ def build_sidebar(app):
     app.file_path_var = ctk.StringVar(master=app, value="")
     ctk.CTkButton(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
         .grid(row=1, column=0, padx=14, pady=(4, 2), sticky="ew")
-    ctk.CTkLabel(card, textvariable=app.file_path_var, wraplength=260, anchor="w", justify="left")\
-        .grid(row=2, column=0, padx=14, pady=(0, 6), sticky="ew")
+    app.file_path_lbl = ctk.CTkLabel(card, textvariable=app.file_path_var, wraplength=260, anchor="w", justify="left")
+    app.file_path_lbl.grid(row=2, column=0, padx=14, pady=(0, 6), sticky="ew")
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
     ctk.CTkButton(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
         .grid(row=3, column=0, padx=14, pady=(2, 2), sticky="ew")
-    ctk.CTkLabel(card, textvariable=app.gl_path_var, wraplength=260, anchor="w", justify="left")\
-        .grid(row=4, column=0, padx=14, pady=(0, 6), sticky="ew")
+    app.gl_path_lbl = ctk.CTkLabel(card, textvariable=app.gl_path_var, wraplength=260, anchor="w", justify="left")
+    app.gl_path_lbl.grid(row=4, column=0, padx=14, pady=(0, 6), sticky="ew")
 
     row_utv = ctk.CTkFrame(card)
     row_utv.grid(row=5, column=0, padx=14, pady=(4, 0), sticky="ew")


### PR DESCRIPTION
## Oppsummering
- Legg til tkinterdnd2 som avhengighet og oppdater installasjonsinstruksene.
- Endre App til å arve fra TkinterDnD.Tk og registrer dra-og-slipp for både fakturaliste og hovedbok.
- Lagre referanser til filfeltene i sidepanelet for å støtte drop-mål.

## Testing
- `python -m py_compile gui/__init__.py gui/sidebar.py`


------
https://chatgpt.com/codex/tasks/task_e_68b729f5812c8328bacea656c7c3b2c5