### PR TITLE
Legg til TkinterDnD i App for drag-and-drop

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -6,6 +6,7 @@ import os
 import tkinter as tk
 import customtkinter as ctk
 from tkinter import filedialog, messagebox
+from tkinterdnd2 import TkinterDnD
 
 
 from helpers import (
@@ -27,9 +28,10 @@ APP_TITLE = "Bilagskontroll v1"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 
 # ----------------- App -----------------
-class App(ctk.CTk):
+class App(ctk.CTk, TkinterDnD.Tk):
     def __init__(self):
-        super().__init__()
+        ctk.CTk.__init__(self)
+        TkinterDnD.Tk.__init__(self)
         ctk.set_appearance_mode("system")
         ctk.set_default_color_theme("blue")
         self.title(APP_TITLE)


### PR DESCRIPTION
## Sammendrag
- Kombinerer CTk og TkinterDnD i App-klassen for å støtte dra-og-slipp
- Initialiserer CTk og TkinterDnD eksplisitt i App.__init__

## Testing
- `python -m py_compile gui/__init__.py`
- `xvfb-run -a python - <<'PY'
from gui import App
app = App()
print('App opprettet')
app.drop_target_register('*')
print('drop_target_register fungerte')
try:
    app.destroy()
except Exception as e:
    print('Feil ved destroy:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b72d6d34c483288ef94b5891832e99