### PR TITLE
Hindre at programmet åpner to vinduer

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -28,10 +28,10 @@ APP_TITLE = "Bilagskontroll v1"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 
 # ----------------- App -----------------
-class App(ctk.CTk, TkinterDnD.Tk):
+class App(ctk.CTk, TkinterDnD.DnDWrapper):
     def __init__(self):
         ctk.CTk.__init__(self)
-        TkinterDnD.Tk.__init__(self)
+        TkinterDnD._require(self)
         ctk.set_appearance_mode("system")
         ctk.set_default_color_theme("blue")
         self.title(APP_TITLE)


### PR DESCRIPTION
## Sammendrag
- Unngå dobbeltinitialisering av Tk for å hindre at GUI åpnes to ganger
- Last inn TkDND-biblioteket uten å opprette ekstra vindu

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python bilagskontroll.py` *(feiler: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b738bdb47c8328bba1fabd61f8f8fc