### PR TITLE
Fargelegg hovedbok-rader etter beslutning

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -22,7 +22,7 @@ from helpers import (
     logger,
 )
 from .sidebar import build_sidebar
-from .mainview import build_main
+from .mainview import build_main, update_decision_colors
 
 APP_TITLE = "Bilagskontroll v1"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
@@ -376,6 +376,7 @@ class App(ctk.CTk, TkinterDnD.DnDWrapper):
             from .ledger import populate_ledger_table
 
             populate_ledger_table(self, inv_val)
+            update_decision_colors(self)
 
             self.comment_box.delete("0.0","end")
             if self.comments and self.idx < len(self.comments) and self.comments[self.idx]:
@@ -386,6 +387,7 @@ class App(ctk.CTk, TkinterDnD.DnDWrapper):
             for item in self.ledger_tree.get_children(): self.ledger_tree.delete(item)
             self.ledger_sum.configure(text="Last gjerne også inn en hovedbok for å se bilagslinjene.")
             self.comment_box.delete("0.0","end")
+            update_decision_colors(self)
 
         if self.sample_df is None or len(self.sample_df) == 0:
             self.btn_prev.configure(state="disabled")

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -83,6 +83,9 @@ def build_main(app):
 
     apply_treeview_theme(app)
     update_treeview_stripes(app)
+    # Farger for radene basert på beslutning
+    app.ledger_tree.tag_configure("approved", foreground="#2ecc71")
+    app.ledger_tree.tag_configure("rejected", foreground="#e74c3c")
 
     app.ledger_sum = ctk.CTkLabel(right, text=" ", anchor="e", justify="right")
     app.ledger_sum.grid(row=3, column=0, columnspan=2, sticky="ew", padx=(0, 12), pady=(6, 10))
@@ -103,3 +106,20 @@ def build_main(app):
     ctk.CTkButton(bottom, text="📄 Eksporter PDF rapport", command=_export_pdf).pack(side="left")
     ctk.CTkLabel(bottom, text="").pack(side="left", expand=True, fill="x")
     return panel
+
+
+def update_decision_colors(app):
+    """Oppdater radfarger i hovedboktabellen etter beslutning."""
+    decision = None
+    if getattr(app, "decisions", None) and app.idx < len(app.decisions):
+        decision = app.decisions[app.idx]
+    tag = None
+    if decision == "Godkjent":
+        tag = "approved"
+    elif decision == "Ikke godkjent":
+        tag = "rejected"
+    for item in app.ledger_tree.get_children():
+        tags = [t for t in app.ledger_tree.item(item, "tags") if t not in ("approved", "rejected")]
+        if tag:
+            tags.append(tag)
+        app.ledger_tree.item(item, tags=tags)


### PR DESCRIPTION
## Endringer
- Fargelegg radene i hovedboktabellen grønt eller rødt avhengig av godkjenning.
- Oppdater radfarger automatisk hver gang hovedvisningen rendres.

## Testing
- `python -m py_compile gui/mainview.py gui/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7db6010188328bc4f151d3e64ac67