### PR TITLE
Utsett GUI-bygging til _init_ui

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -29,10 +29,6 @@ class App(ctk.CTk):
     def __init__(self):
         ctk.CTk.__init__(self)
 
-        # Utsett import til vi faktisk trenger modulene
-        from .sidebar import build_sidebar
-        from .mainview import build_main
-
         self._dnd_ready = False
         self._icon_ready = False
 
@@ -68,6 +64,18 @@ class App(ctk.CTk):
         self.logo_img = None
         self._after_jobs = []
 
+        self.after(0, self._init_ui)
+
+    def _init_ui(self):
+        try:
+            from tkinterdnd2 import TkinterDnD
+        except Exception:
+            TkinterDnD = None
+        from .sidebar import build_sidebar
+        from .mainview import build_main
+
+        self._TkinterDnD = TkinterDnD
+
         self.grid_columnconfigure(0, weight=0)
         self.grid_columnconfigure(1, weight=1)
         self.grid_rowconfigure(0, weight=1)
@@ -84,11 +92,12 @@ class App(ctk.CTk):
         self._after_jobs.append(self.after_idle(self._init_dnd))
         self._after_jobs.append(self.after_idle(self._init_icon))
 
-        # Sørg for ryddig nedstenging
         self.protocol("WM_DELETE_WINDOW", self.destroy)
 
     def _init_dnd(self):
-        from tkinterdnd2 import TkinterDnD
+        TkinterDnD = getattr(self, "_TkinterDnD", None)
+        if not TkinterDnD:
+            return
 
         self.__class__ = type(
             self.__class__.__name__, (self.__class__, TkinterDnD.DnDWrapper), {}


### PR DESCRIPTION
## Endringer
- Flyttet tunge imports og widget-initialisering til ny metode `_init_ui` som kjøres etter at loopen starter
- La bindinger, `render()` og etter-oppgaver inn i `_init_ui`
- Forhåndslast `TkinterDnD` i `_init_ui` og bruk modul i `_init_dnd`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9994da4708328a82571bfc9e03eb3