### PR TITLE
Utsetter import av Tkinter til oppstart

### DIFF
--- a/report.py
+++ b/report.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 from datetime import datetime
-from tkinter import filedialog
 
 from helpers import (
     to_str,
@@ -37,6 +36,8 @@ def export_pdf(app):
 
     from report_utils import build_ledger_table
     now = datetime.now()
+    from tkinter import filedialog
+
     save = filedialog.asksaveasfilename(
         title="Lagre PDF-rapport",
         defaultextension=".pdf",


### PR DESCRIPTION
## Sammendrag
- Definerer hjelpefunksjoner som importerer `filedialog` og `messagebox` kun ved behov
- Flytter `filedialog`-import i `report.py` inn i funksjonen for å unngå tidlig Tkinter-lasting

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99bcd657083288732e42f1e855b6e