### PR TITLE
Utsett import av RotatingFileHandler for raskere oppstart

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -3,7 +3,6 @@ import os
 import re
 import sys
 import logging
-from logging.handlers import RotatingFileHandler
 
 
 def setup_logger(log_path: str = "bilagskontroll.log") -> logging.Logger:
@@ -19,6 +18,9 @@ def setup_logger(log_path: str = "bilagskontroll.log") -> logging.Logger:
     logging.Logger
         Konfigurert logger for applikasjonen.
     """
+
+    # Importeres her for å unngå unødvendig overhead ved programoppstart.
+    from logging.handlers import RotatingFileHandler
 
     logger = logging.getLogger("bilagskontroll")
     if not logger.handlers:


### PR DESCRIPTION
## Oppsummering
- Flytt import av `RotatingFileHandler` inn i `setup_logger` for å unngå unødig lasting ved programstart.

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6f57f488328879f00d7c06af711