### PR TITLE
Utsett post-init for raskere oppstart

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -76,7 +76,7 @@ class App:
         self.logo_img = None
         self._init_theme()
         self._init_ui()
-        self._post_init()
+        self.after_idle(self._post_init)
 
     def _init_ui(self):
         try:


### PR DESCRIPTION
## Oppsummering
- Flytter `_post_init` til `after_idle` slik at logo, DnD og ikon lastes etter at vinduet vises

## Testing
- `PYTHONPATH=. pytest -q`
- `xvfb-run -a python - <<'PY'
from gui import App

app = App()
app.update_idletasks()
print('dnd', app._dnd_ready, 'icon', app._icon_ready, 'logo', app.logo_img is not None)
app.destroy()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bafbc5f4f48328843f7b8681569908