### PR TITLE
Gjenbruk av fontkonstanter i GUI

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -9,6 +9,10 @@ import re
 APP_TITLE = "Bilagskontroll"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 
+# Delte skrifttyper
+FONT_TITLE = None
+FONT_BODY = None
+
 # ----------------- App -----------------
 class App:
     def __init__(self):
@@ -27,6 +31,11 @@ class App:
 
         self.__class__ = type(self.__class__.__name__, (ctk.CTk, self.__class__), {})
         ctk.CTk.__init__(self)
+
+        globals().update(
+            FONT_TITLE=ctk.CTkFont(size=16, weight="bold"),
+            FONT_BODY=ctk.CTkFont(size=14),
+        )
 
         self._dnd_ready = False
         self._icon_ready = False

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,3 +1,6 @@
+from . import FONT_TITLE, FONT_BODY
+
+
 def build_main(app):
     from tkinter import ttk
     import customtkinter as ctk
@@ -17,10 +20,10 @@ def build_main(app):
     head.grid(row=0, column=0, sticky="ew", padx=12, pady=8)
     head.grid_columnconfigure(6, weight=1)
 
-    bold_font = ctk.CTkFont(size=16, weight="bold")
+    # Spesiell font: større uten fet skrift
     head_font = ctk.CTkFont(size=16)
 
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=bold_font)
+    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=FONT_TITLE)
     app.lbl_status = ctk.CTkLabel(head, text="Status: –", font=head_font)
     app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
     app.lbl_count.grid(row=0, column=0, padx=(4, 12))
@@ -58,14 +61,14 @@ def build_main(app):
     right.grid(row=0, column=1, sticky="nsew")
 
     ctk.CTkLabel(left, text="Detaljer for bilag", font=ctk.CTkFont(size=15, weight="bold"))\
-        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))
+        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))  # Spesiell font: 15pt tittel
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
-    app.detail_box = ctk.CTkTextbox(left, height=360, font=ctk.CTkFont(size=14))
+    app.detail_box = ctk.CTkTextbox(left, height=360, font=FONT_BODY)
     app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(8,6), pady=(0,8))
 
     ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=ctk.CTkFont(size=15, weight="bold"))\
-        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))
+        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))  # Spesiell font: 15pt tittel
     right.grid_columnconfigure(0, weight=1)
     right.grid_columnconfigure(1, weight=0)
     right.grid_rowconfigure(1, weight=3, minsize=150)
@@ -100,8 +103,8 @@ def build_main(app):
     app.ledger_sum.grid(row=3, column=0, columnspan=2, sticky="ew", padx=(0, 12), pady=(6, 10))
 
     ctk.CTkLabel(right, text="Kommentar", font=ctk.CTkFont(size=15, weight="bold"))\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(8, 6), pady=(8, 4))
-    app.comment_box = ctk.CTkTextbox(right, height=110, font=ctk.CTkFont(size=13))
+        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(8, 6), pady=(8, 4))  # Spesiell font: 15pt tittel
+    app.comment_box = ctk.CTkTextbox(right, height=110, font=ctk.CTkFont(size=13))  # Spesiell liten font
     app.comment_box.grid(row=5, column=0, columnspan=2, sticky="nsew", padx=(8, 6), pady=(0, 0))
 
     bottom = ctk.CTkFrame(panel)

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,4 +1,5 @@
 import os
+from . import FONT_TITLE, FONT_BODY
 
 
 def _toggle_sample_btn(app, *_):
@@ -13,7 +14,7 @@ def build_sidebar(app):
     card.grid(row=0, column=0, sticky="nsw", padx=14, pady=14)
 
     ctk.CTkLabel(card, text="⚙️ Innstillinger", font=ctk.CTkFont(size=18, weight="bold"))\
-        .grid(row=0, column=0, padx=14, pady=(14, 6), sticky="w")
+        .grid(row=0, column=0, padx=14, pady=(14, 6), sticky="w")  # Spesiell font: stor tittel
 
     app.file_path_var = ctk.StringVar(master=app, value="")
     ctk.CTkButton(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
@@ -71,11 +72,11 @@ def build_sidebar(app):
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
     app.year_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
 
-    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=ctk.CTkFont(size=16, weight="bold"))
+    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=FONT_TITLE)
     app.lbl_filecount.grid(row=7, column=0, padx=14, pady=(2, 2), sticky="w")
 
     ctk.CTkLabel(card, text="Oppdragsinfo", font=ctk.CTkFont(size=14, weight="bold"))\
-        .grid(row=8, column=0, padx=14, pady=(8, 2), sticky="w")
+        .grid(row=8, column=0, padx=14, pady=(8, 2), sticky="w")  # Spesiell font: 14pt fet
     opp = ctk.CTkFrame(card, corner_radius=8)
     opp.grid(row=9, column=0, padx=14, pady=(0, 8), sticky="ew")
     opp.grid_columnconfigure(0, weight=0)
@@ -104,7 +105,7 @@ def build_sidebar(app):
     info_lbl = ctk.CTkLabel(
         opp,
         text="Kundenavn hentes automatisk",
-        font=ctk.CTkFont(size=12, slant="italic"),
+        font=ctk.CTkFont(size=12, slant="italic"),  # Spesiell font: liten og kursiv
         anchor="w",
         justify="left",
         wraplength=240,
@@ -114,7 +115,7 @@ def build_sidebar(app):
     card.grid_rowconfigure(20, weight=1)
 
     ctk.CTkLabel(card, text="Tema", font=ctk.CTkFont(size=13))\
-        .grid(row=101, column=0, padx=14, pady=(0, 0), sticky="w")
+        .grid(row=101, column=0, padx=14, pady=(0, 0), sticky="w")  # Spesiell font: 13pt
     theme = ctk.CTkSegmentedButton(card, values=["System", "Light", "Dark"], command=app._switch_theme)
     theme.set("System")
     theme.grid(row=102, column=0, padx=14, pady=(2, 14), sticky="ew")
@@ -123,8 +124,8 @@ def build_sidebar(app):
     status_card.grid(row=100, column=0, padx=14, pady=(8, 14), sticky="ew")
     status_card.grid_columnconfigure(0, weight=1)
 
-    title_font = ctk.CTkFont(size=18, weight="bold")
-    body_font = ctk.CTkFont(size=14)
+    title_font = ctk.CTkFont(size=18, weight="bold")  # Spesiell font: større enn vanlig tittel
+    body_font = FONT_BODY
 
     ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
         .grid(row=0, column=0, sticky="ew", pady=(10, 6))


### PR DESCRIPTION
## Sammendrag
- Definerte `FONT_TITLE` og `FONT_BODY` i `gui/__init__.py`
- Bruker fontkonstantene i `mainview` og `sidebar` for felles stil
- Dokumenterte og beholdt spesialfonter der det trengs

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb0690f6d883288eb1268d7e5f5a7c