### PR TITLE
Legg til tester for nettobeløp

### DIFF
--- a/tests/test_calc_sum_net_all.py
+++ b/tests/test_calc_sum_net_all.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from data_utils import calc_sum_net_all
+
+
+def test_calc_sum_net_all_uten_summeringsrad():
+    df = pd.DataFrame({
+        'tekst': ['rad1', 'rad2', None],
+        'netto': [100.0, 200.0, 0.0]
+    })
+    assert calc_sum_net_all(df, 'netto') == 300.0
+
+
+def test_calc_sum_net_all_med_summeringsrader():
+    df = pd.DataFrame({
+        'tekst': ['rad1', 'Sum', 'rad2', 'SUM'],
+        'netto': [100.0, 999.0, 200.0, 300.0]
+    })
+    assert calc_sum_net_all(df, 'netto') == 300.0
+
+
+def test_calc_sum_net_all_kun_summeringsrad():
+    df = pd.DataFrame({
+        'tekst': ['Sum'],
+        'netto': [123.0]
+    })
+    assert calc_sum_net_all(df, 'netto') == 0.0


### PR DESCRIPTION
## Sammendrag
- Tester at `calc_sum_net_all` returnerer korrekt sum når siste rad ikke er en summering
- Sikrer at rader med ordet "Sum" ignoreres i beregningen
- Verifiserer at kun summeringsrad gir totalsum 0

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb19d156bc8328a835111bf206cb46