### PR TITLE
Forhåndslesing av hovedbok for å finne riktig header

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -29,14 +29,19 @@ def load_invoice_df(path: str, header_idx: int = 4) -> pd.DataFrame:
     return pd.read_excel(path, engine="openpyxl", header=header_idx)
 
 
-def load_gl_df(path: str) -> pd.DataFrame:
-    """Leser hovedboken fra Excel."""
+def load_gl_df(path: str, nrows: int = 10) -> pd.DataFrame:
+    """Leser hovedboken fra Excel.
+
+    Leser først ``nrows`` rader for å avgjøre korrekt header og leser deretter
+    hele filen én gang med riktig header.
+    """
     logger.info(f"Laster hovedbok fra {path}")
     pd = _pd()
-    gl = pd.read_excel(path, engine="openpyxl", header=0)
-    if sum(str(c).lower().startswith("unnamed") for c in gl.columns) > len(gl.columns) / 2:
-        gl = pd.read_excel(path, engine="openpyxl", header=4)
-    return gl
+    preview = pd.read_excel(path, engine="openpyxl", header=0, nrows=nrows)
+    header_idx = 0
+    if sum(str(c).lower().startswith("unnamed") for c in preview.columns) > len(preview.columns) / 2:
+        header_idx = 4
+    return pd.read_excel(path, engine="openpyxl", header=header_idx)
 
 
 def extract_customer_from_invoice_file(path: str) -> Optional[str]:

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -425,7 +425,7 @@ class App:
             self.inline_status.configure(text="laster inn fil...")
             self.inline_status.update_idletasks()
         try:
-            gl = load_gl_df(path)
+            gl = load_gl_df(path, nrows=10)
         except Exception as e:
             messagebox.showerror(APP_TITLE, f"Klarte ikke lese hovedbok:\n{e}")
             return


### PR DESCRIPTION
## Sammendrag
- les noen rader for å velge korrekt header før full innlesing
- leser hovedbok bare én gang med den oppdagede headeren
- oppdaterer GUI-kall til den nye logikken

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc63a6d3c8832890e1c7109ebfaf52