### PR TITLE
Utvid stil med temafarger og fargeoppslag

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -24,15 +24,8 @@ def _ctk():
 APP_TITLE = "Bilagskontroll"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 
-def get_color(name: str) -> str:
-    """Returner farge basert på gjeldende tema."""
-    ctk = _ctk()
-
-    mode = ctk.get_appearance_mode().lower()
-    try:
-        return style.COLORS[name]["dark" if mode == "dark" else "light"]
-    except KeyError as e:
-        raise KeyError(f"Ukjent fargenavn: {name}") from e
+# For bakoverkompatibilitet
+get_color = style.get_color
 
 
 def create_button(master, **kwargs):
@@ -602,7 +595,7 @@ class App:
     # Inline
     def _show_inline(self, msg: str, ok=True):
         self.inline_status.configure(
-            text_color=(get_color("success") if ok else get_color("error"))
+            text_color=(style.get_color("success") if ok else style.get_color("error"))
         )
         self.inline_status.configure(text=msg)
         self.after(3500, lambda: self.inline_status.configure(text=""))

--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -4,19 +4,20 @@ LEDGER_COLS = ["Kontonr", "Konto", "Beskrivelse", "MVA", "MVA-beløp", "Beløp",
 def apply_treeview_theme(app):
     from tkinter import ttk
     import customtkinter as ctk
+    from .style import style
 
-    style = ttk.Style()
+    ttk_style = ttk.Style()
     try:
-        style.theme_use("clam")
+        ttk_style.theme_use("clam")
     except Exception:
         pass
-    mode = ctk.get_appearance_mode().lower()
-    if mode == "dark":
-        bg = "#1e1e1e"; fg = "#e6e6e6"; hb = "#2a2a2a"; sel_bg = "#3a3a3a"; sel_fg = "#ffffff"
-    else:
-        bg = "#ffffff"; fg = "#000000"; hb = "#f0f0f0"; sel_bg = "#d0d0ff"; sel_fg = "#000000"
     font = app.detail_box.cget("font") if hasattr(app, "detail_box") else ctk.CTkFont(size=14)
-    style.configure(
+    bg = style.get_color("table_bg")
+    fg = style.get_color("table_fg")
+    hb = style.get_color("table_header_bg")
+    sel_bg = style.get_color("table_sel_bg")
+    sel_fg = style.get_color("table_sel_fg")
+    ttk_style.configure(
         "Custom.Treeview",
         background=bg,
         fieldbackground=bg,
@@ -25,22 +26,25 @@ def apply_treeview_theme(app):
         borderwidth=0,
         font=font,
     )
-    style.configure("Custom.Treeview.Heading",
-                    background=hb, foreground=fg, borderwidth=0)
-    style.map("Custom.Treeview",
-              background=[("selected", sel_bg)],
-              foreground=[("selected", sel_fg)])
+    ttk_style.configure(
+        "Custom.Treeview.Heading",
+        background=hb,
+        foreground=fg,
+        borderwidth=0,
+    )
+    ttk_style.map(
+        "Custom.Treeview",
+        background=[("selected", sel_bg)],
+        foreground=[("selected", sel_fg)],
+    )
     app.ledger_tree.configure(style="Custom.Treeview")
 
 
 def update_treeview_stripes(app):
-    import customtkinter as ctk
+    from .style import style
 
-    mode = ctk.get_appearance_mode().lower()
-    if mode == "dark":
-        odd = "#232323"; even = "#1e1e1e"
-    else:
-        odd = "#f6f6f6"; even = "#ffffff"
+    odd = style.get_color("table_row_odd")
+    even = style.get_color("table_row_even")
     app.ledger_tree.tag_configure("odd", background=odd)
     app.ledger_tree.tag_configure("even", background=even)
 

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,4 +1,4 @@
-from . import create_button, get_color
+from . import create_button
 from .style import style
 
 
@@ -19,10 +19,10 @@ def build_header(app):
     app.lbl_status.grid(row=0, column=1, padx=style.PAD_MD)
     app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
     create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
-    app.copy_feedback = ctk.CTkLabel(head, text="", text_color=get_color("success"))
+    app.copy_feedback = ctk.CTkLabel(head, text="", text_color=style.get_color("success"))
     app.copy_feedback.grid(row=0, column=4, padx=style.PAD_MD, sticky="w")
 
-    app.inline_status = ctk.CTkLabel(head, text="", text_color=get_color("success"))
+    app.inline_status = ctk.CTkLabel(head, text="", text_color=style.get_color("success"))
     app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
 
     return head
@@ -39,15 +39,15 @@ def build_action_buttons(app):
     create_button(
         btns,
         text="✅ Godkjent",
-        fg_color=get_color("success"),
-        hover_color=get_color("success_hover"),
+        fg_color=style.get_color("success"),
+        hover_color=style.get_color("success_hover"),
         command=lambda: app.set_decision_and_next("Godkjent"),
     ).grid(row=0, column=0, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
     create_button(
         btns,
         text="⛔ Ikke godkjent",
-        fg_color=get_color("error"),
-        hover_color=get_color("error_hover"),
+        fg_color=style.get_color("error"),
+        hover_color=style.get_color("error_hover"),
         command=lambda: app.set_decision_and_next("Ikke godkjent"),
     ).grid(row=0, column=1, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
     create_button(btns, text="🔗 Åpne i PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
@@ -118,7 +118,7 @@ def build_bottom(app):
     pb_style = ttk.Style()
     pb_style.configure(
         "green.Horizontal.TProgressbar",
-        background=get_color("success"),
+        background=style.get_color("success"),
     )
     app.progress_bar = ttk.Progressbar(
         bottom,

--- a/gui/style.py
+++ b/gui/style.py
@@ -18,8 +18,29 @@ class Style:
             "success_hover": {"light": "#29b765", "dark": "#219150"},
             "error": {"light": "#e74c3c", "dark": "#c0392b"},
             "error_hover": {"light": "#cf4334", "dark": "#992d22"},
+            # Generelle farger
+            "bg": {"light": "#ffffff", "dark": "#1e1e1e"},
+            "fg": {"light": "#000000", "dark": "#e6e6e6"},
+            # Tabellfarger
+            "table_bg": {"light": "#ffffff", "dark": "#1e1e1e"},
+            "table_fg": {"light": "#000000", "dark": "#e6e6e6"},
+            "table_header_bg": {"light": "#f0f0f0", "dark": "#2a2a2a"},
+            "table_sel_bg": {"light": "#d0d0ff", "dark": "#3a3a3a"},
+            "table_sel_fg": {"light": "#000000", "dark": "#ffffff"},
+            "table_row_odd": {"light": "#f6f6f6", "dark": "#232323"},
+            "table_row_even": {"light": "#ffffff", "dark": "#1e1e1e"},
         }
     )
+
+    def get_color(self, name: str) -> str:
+        """Returner farge tilpasset valgt tema."""
+        import customtkinter as ctk
+
+        mode = ctk.get_appearance_mode().lower()
+        try:
+            return self.COLORS[name]["dark" if mode == "dark" else "light"]
+        except KeyError as e:
+            raise KeyError(f"Ukjent fargenavn: {name}") from e
 
     # Skrifttyper (initialiseres lazily)
     FONT_TITLE: Optional[object] = None


### PR DESCRIPTION
## Endringer
- la til bakgrunns-, tekst- og tabellfarger for lys og mørk drakt
- eksponerte `style.get_color` og byttet ut hardkodede farger i GUI
- oppdaterte `ledger` og `mainview` til å hente farger fra `style`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd50ef49c08328809f95a48113a75c