### PR TITLE
Rett melding ved lasterekkefølgen hovedbok/fakturaliste

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -720,9 +720,12 @@ class App:
                     for item in self.ledger_tree.get_children():
                         self.ledger_tree.delete(item)
                 if hasattr(self, "ledger_sum"):
-                    self.ledger_sum.configure(
-                        text="Last gjerne også inn en hovedbok for å se bilagslinjene."
+                    msg = (
+                        "Last gjerne også inn en hovedbok for å se bilagslinjene."
+                        if getattr(self, "gl_df", None) is None
+                        else ""
                     )
+                    self.ledger_sum.configure(text=msg)
 
             self.comment_box.delete("0.0","end")
             if self.comments and self.idx < len(self.comments) and self.comments[self.idx]:
@@ -734,9 +737,12 @@ class App:
                 for item in self.ledger_tree.get_children():
                     self.ledger_tree.delete(item)
             if hasattr(self, "ledger_sum"):
-                self.ledger_sum.configure(
-                    text="Last gjerne også inn en hovedbok for å se bilagslinjene."
+                msg = (
+                    "Last gjerne også inn en hovedbok for å se bilagslinjene."
+                    if getattr(self, "gl_df", None) is None
+                    else "Trekk utvalg for å se bilagslinjene."
                 )
+                self.ledger_sum.configure(text=msg)
             self.comment_box.delete("0.0","end")
 
         if self.sample_df is None or len(self.sample_df) == 0:

--- a/tests/test_ledger_message.py
+++ b/tests/test_ledger_message.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import gui
+from gui import App
+
+
+class DummyWidget:
+    def __init__(self):
+        self.cfg = {}
+    def configure(self, **kwargs):
+        self.cfg.update(kwargs)
+    def delete(self, *args, **kwargs):
+        pass
+    def insert(self, *args, **kwargs):
+        pass
+    def get_children(self):
+        return []
+
+
+class FakeApp:
+    def __init__(self):
+        self.df = pd.DataFrame({'Faktura':[1], 'Beløp':[100]})
+        self.sample_df = None
+        self.idx = 0
+        self.invoice_col = 'Faktura'
+        self.net_amount_col = 'Beløp'
+        self.decisions = []
+        self.comments = []
+        self.lbl_count = DummyWidget()
+        self.lbl_invoice = DummyWidget()
+        self.lbl_status = DummyWidget()
+        self.detail_box = DummyWidget()
+        self.ledger_tree = DummyWidget()
+        self.ledger_sum = DummyWidget()
+        self.comment_box = DummyWidget()
+        self.btn_prev = DummyWidget()
+        self.btn_next = DummyWidget()
+        self.gl_df = pd.DataFrame({'A':[1]})
+    def _ensure_helpers(self):
+        gui.to_str = str
+        gui.format_number_with_thousands = lambda x: x
+    def _update_counts_labels(self):
+        pass
+    def _current_row_dict(self):
+        return {}
+    def _details_text_for_row(self, row_dict):
+        return ""
+    def _update_status_card_safe(self):
+        pass
+
+
+def test_message_when_gl_loaded_but_no_sample():
+    app = FakeApp()
+    App.render(app)
+    assert app.ledger_sum.cfg["text"] == "Trekk utvalg for å se bilagslinjene."


### PR DESCRIPTION
## Sammendrag
- Unngå misvisende melding om manglende hovedbok når hovedbok er lastet før fakturaliste
- Legg til test som sikrer riktig melding når hovedbok er lastet uten utvalg

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be74a9ed8c83289dda578ff2afb8b8