### PR TITLE
Debounce kolonnebredde for hovedbok

### DIFF
--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -172,7 +172,16 @@ def build_main(app):
 def resize_ledger_columns(app):
     from . import ledger
     width = app.ledger_tree.winfo_width()
-    ledger.autofit_tree_columns(app.ledger_tree, app.ledger_cols, width)
+    if getattr(app, "_prev_ledger_width", None) == width:
+        return
+
+    app._prev_ledger_width = width
+    app.after(
+        100,
+        lambda: ledger.autofit_tree_columns(
+            app.ledger_tree, app.ledger_cols, width
+        ),
+    )
 
 
 def build_ledger_widgets(app):
@@ -213,6 +222,7 @@ def build_ledger_widgets(app):
     yscroll.grid(row=1, column=1, sticky="ns")
     xscroll.grid(row=2, column=0, sticky="ew")
 
+    app._prev_ledger_width = None
     app._ledger_configure_id = app.ledger_tree.bind(
         "<Configure>", lambda e: resize_ledger_columns(app)
     )


### PR DESCRIPTION
## Endringer
- Utsett tilpasning av hovedbok-kolonner med `app.after(100, ...)`
- Unngå unødige beregninger ved å lagre forrige bredde
- Initialiser `_prev_ledger_width` når hovedboken bygges

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec3b3f3ac8328b5b32504c7ecd06f