### PR TITLE
Flytt loggfiler til egen mappe

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel�
 - Deaktiverer navigasjonsknappene ved første og siste bilag for å hindre ugyldig navigering
 - Validerer tallfelt i grensesnittet for å sikre gyldige inputverdier
 - PDF‑rapporten viser tidspunkt for når den ble generert
-- Logger hendelser til fil og oppretter loggkatalogen automatisk ved behov
+- Logger hendelser til fil i mappen `logs/` og oppretter loggkatalogen automatisk ved behov
 - Dra-og-slipp av filer viser en ventedialog mens filer lastes inn
 - Kolonnebredder i hovedboken tilpasser seg når vinduet endres
 - Grensesnittet støtter mørk modus

--- a/helpers.py
+++ b/helpers.py
@@ -5,13 +5,13 @@ import sys
 import logging
 
 
-def setup_logger(log_path: str = "bilagskontroll.log") -> logging.Logger:
+def setup_logger(log_path: str = "logs/bilagskontroll.log") -> logging.Logger:
     """Sett opp logger med roterende filhåndtering.
 
     Parametere
     ----------
     log_path : str, optional
-        Sti til loggfilen. Standard er ``bilagskontroll.log``.
+        Sti til loggfilen. Standard er ``logs/bilagskontroll.log``.
 
     Returnerer
     ----------

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,3 @@
+# Ignorerer loggfiler
+*
+!.gitignore

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import helpers
 
+
 def test_logger_delayed_file_creation(tmp_path, monkeypatch):
     logger = logging.getLogger("bilagskontroll")
     for handler in logger.handlers[:]:
@@ -13,7 +14,7 @@ def test_logger_delayed_file_creation(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     module = importlib.reload(helpers)
 
-    log_file = Path(tmp_path) / "bilagskontroll.log"
+    log_file = Path(tmp_path) / "logs" / "bilagskontroll.log"
     assert not log_file.exists()
 
     module.logger.info("første melding")


### PR DESCRIPTION
## Sammendrag
- Loggeren skriver nå til `logs/bilagskontroll.log`
- Oppdatert test og README med ny loggsti
- Lagt til `.gitignore` for å ignorere loggfiler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c013396dfc83288f28a01b210cdfcd