### PR TITLE
Vis sorteringspil i hovedboktabellen

### DIFF
--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -65,7 +65,18 @@ def sort_treeview(tree, col, reverse, app):
     for idx, iid in enumerate(tree.get_children("")):
         tag = "even" if idx % 2 == 0 else "odd"
         tree.item(iid, tags=(tag,))
-    tree.heading(col, command=lambda: sort_treeview(tree, col, not reverse, app))
+    arrow = "↓" if reverse else "↑"
+    for c in LEDGER_COLS:
+        if c == col:
+            tree.heading(
+                c,
+                text=f"{c} {arrow}",
+                command=lambda c=c: sort_treeview(tree, c, not reverse, app),
+            )
+        else:
+            tree.heading(
+                c, text=c, command=lambda c=c: sort_treeview(tree, c, False, app)
+            )
     update_treeview_stripes(app)
 
 

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -230,6 +230,9 @@ def build_ledger_widgets(app):
     apply_treeview_theme(app)
     update_treeview_stripes(app)
 
+    if app.ledger_tree.get_children():
+        sort_treeview(app.ledger_tree, app.ledger_cols[0], False, app)
+
     app.ledger_sum = ctk.CTkLabel(right, text=" ", anchor="e", justify="right")
     app.ledger_sum.grid(
         row=3,


### PR DESCRIPTION
## Oppsummering
- Viser pil opp eller ned i kolonneoverskrifter når tabellen sorteres og nullstiller andre kolonner.
- Initialiserer overskrifter uten pil og re-sorterer første kolonne hvis det finnes rader.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04093164c83288591e1b9054d626b