### PR TITLE
Refaktorer dra-og-slipp med DropZone

### DIFF
--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -1,1 +1,48 @@
+import customtkinter as ctk
+from .style import style
 
+
+class DropZone(ctk.CTkFrame):
+    """En ramme for dra-og-slipp med fargeendring ved drag hendelser."""
+
+    def __init__(self, parent, text: str, drop_callback):
+        dnd_bg = style.get_color_pair("dnd_bg")
+        dnd_border = style.get_color_pair("dnd_border")
+        highlight = style.get_color_pair("success")
+
+        super().__init__(
+            parent,
+            height=70,
+            corner_radius=style.BTN_RADIUS,
+            fg_color=dnd_bg,
+            border_color=dnd_border,
+            border_width=2,
+        )
+
+        self._dnd_bg = dnd_bg
+        self._dnd_border = dnd_border
+        self._highlight = highlight
+        self.drop_callback = drop_callback
+
+        ctk.CTkLabel(
+            self,
+            text=text,
+            anchor="center",
+            text_color=dnd_border,
+        ).pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
+
+        for evt in ("<<DragEnter>>", "<<DropEnter>>"):
+            self.dnd_bind(evt, self._on_drag_enter)
+        for evt in ("<<DragLeave>>", "<<DropLeave>>"):
+            self.dnd_bind(evt, self.reset_colors)
+
+    def _on_drag_enter(self, _):
+        self.configure(fg_color=self._highlight, border_color=self._highlight)
+
+    def reset_colors(self, _=None):
+        self.configure(fg_color=self._dnd_bg, border_color=self._dnd_border)
+
+    def on_drop(self, event):
+        self.reset_colors()
+        if self.drop_callback:
+            return self.drop_callback(event)

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,6 +1,7 @@
 import os
 from . import create_button
 from .style import style, PADDING_Y
+from .dropzone import DropZone
 
 SIDEBAR_LOGO_WIDTH = 200
 
@@ -22,57 +23,7 @@ def build_sidebar(app):
     app.file_path_var = ctk.StringVar(master=app, value="")
     create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
         .grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
-    def _create_drop_zone(parent, text):
-        dnd_bg = style.get_color_pair("dnd_bg")
-        dnd_border = style.get_color_pair("dnd_border")
-        highlight = style.get_color_pair("success")
-
-        frame = ctk.CTkFrame(
-            parent,
-            height=70,
-            corner_radius=style.BTN_RADIUS,
-            fg_color=dnd_bg,
-            border_color=dnd_border,
-            border_width=2,
-        )
-
-        def _reset_colors(_=None):
-            frame.configure(fg_color=dnd_bg, border_color=dnd_border)
-
-        def _on_drag_enter(_):
-            frame.configure(fg_color=highlight, border_color=highlight)
-
-        # Nokre TkDND-versjonar brukar DropEnter/DropLeave i staden for DragEnter/DragLeave
-        for evt in ("<<DragEnter>>", "<<DropEnter>>"):
-            frame.dnd_bind(evt, _on_drag_enter)
-        for evt in ("<<DragLeave>>", "<<DropLeave>>"):
-            frame.dnd_bind(evt, _reset_colors)
-
-        ctk.CTkLabel(
-            frame,
-            text=text,
-            anchor="center",
-            text_color=dnd_border,
-        ).pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
-
-        frame.reset_colors = _reset_colors
-        return frame
-
-    app.inv_drop = _create_drop_zone(card, "Dra og slipp fakturaliste her")
-    app.inv_drop.grid(row=2, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
-    ctk.CTkLabel(card, textvariable=app.file_path_var, wraplength=260, anchor="w", justify="left")\
-        .grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
-
-    app.gl_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
-        .grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
-    app.gl_drop = _create_drop_zone(card, "Dra og slipp hovedbok her")
-    app.gl_drop.grid(row=5, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
-    ctk.CTkLabel(card, textvariable=app.gl_path_var, wraplength=260, anchor="w", justify="left")\
-        .grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
-
     def _drop_invoice(event):
-        app.inv_drop.reset_colors()
         path = event.data.strip("{}").strip()
         if not path.lower().endswith((".xlsx", ".xls")):
             return
@@ -80,10 +31,17 @@ def build_sidebar(app):
         from .busy import show_busy
         show_busy(app, "Laster fakturaliste...")
         app._load_excel()
-        app.inv_drop.reset_colors()
+
+    app.inv_drop = DropZone(card, "Dra og slipp fakturaliste her", _drop_invoice)
+    app.inv_drop.grid(row=2, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
+    ctk.CTkLabel(card, textvariable=app.file_path_var, wraplength=260, anchor="w", justify="left")\
+        .grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+
+    app.gl_path_var = ctk.StringVar(master=app, value="")
+    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
+        .grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
 
     def _drop_gl(event):
-        app.gl_drop.reset_colors()
         path = event.data.strip("{}").strip()
         if not path.lower().endswith((".xlsx", ".xls")):
             return
@@ -91,10 +49,14 @@ def build_sidebar(app):
         from .busy import show_busy
         show_busy(app, "Laster hovedbok...")
         app._load_gl_excel()
-        app.gl_drop.reset_colors()
 
-    app.add_drop_target(app.inv_drop, _drop_invoice)
-    app.add_drop_target(app.gl_drop, _drop_gl)
+    app.gl_drop = DropZone(card, "Dra og slipp hovedbok her", _drop_gl)
+    app.gl_drop.grid(row=5, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
+    ctk.CTkLabel(card, textvariable=app.gl_path_var, wraplength=260, anchor="w", justify="left")\
+        .grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+
+    app.add_drop_target(app.inv_drop, app.inv_drop.on_drop)
+    app.add_drop_target(app.gl_drop, app.gl_drop.on_drop)
 
     row_utv = ctk.CTkFrame(card)
     row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")


### PR DESCRIPTION
## Oppsummering
- Legger til DropZone-klasse som håndterer farger og drop-callback.
- Erstatter intern dropzone-logikk i sidepanelet med DropZone-instansene.
- Registrerer drop-sonene som mål via `add_drop_target`.

## Testing
- `pip install pandas openpyxl`
- `pip install reportlab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2c9f880c883288459ea13b44d5192