### PR TITLE
Vektorisér filtrering av summeringsrader i calc_sum_net_all

### DIFF
--- a/tests/test_calc_sum_net_all.py
+++ b/tests/test_calc_sum_net_all.py
@@ -36,3 +36,13 @@ def test_calc_sum_net_all_beholder_siste_rad_uten_sum():
     })
     df['_netto_float'] = df['netto']
     assert calc_sum_net_all(df) == 600.0
+
+
+def test_calc_sum_net_all_med_sum_i_annen_kolonne():
+    df = pd.DataFrame({
+        'tekst': ['rad1', 'rad2'],
+        'kommentar': ['ok', 'sum her'],
+        'netto': [100.0, 200.0]
+    })
+    df['_netto_float'] = df['netto']
+    assert calc_sum_net_all(df) == 100.0


### PR DESCRIPTION
## Oppsummering
- Bruk vektorisert `stack()` og prekompilert regex for å filtrere bort summeringsrader i `calc_sum_net_all`
- Ekskluder rader med `sum` i alle kolonner og behold siste rad når den ikke er en summering
- Utvid testdekningen for å kontrollere summeringsord i flere kolonner

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2ccb65ed483288b54266ed7a88a40