### PR TITLE
Støtte for beløp i parentes

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -104,6 +104,10 @@ def parse_amount(x):
     if not s or s.lower() == "nan":
         return None
     s = s.replace(",", ".")
+    if s.startswith("(") and s.endswith(")"):
+        inner = s[1:-1]
+        if inner.replace(".", "", 1).isdigit():
+            s = "-" + inner
     if s.endswith("-") and s[:-1].replace(".", "", 1).isdigit():
         s = "-" + s[:-1]
     try:

--- a/tests/test_parse_amount.py
+++ b/tests/test_parse_amount.py
@@ -1,0 +1,6 @@
+from helpers import parse_amount
+
+
+def test_parse_amount_parenteser():
+    assert parse_amount("(123)") == -123.0
+    assert parse_amount("(123,45)") == -123.45


### PR DESCRIPTION
## Oppsummering
- tolker nå beløp skrevet som `(123)` som `-123`
- la til enhetstest som dekker tolking av parentesbeløp

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2e6696c348328867a2dc215d331a4