### PR TITLE
Beløp-kolonne tilpasser seg beløpets bredde

### DIFF
--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -137,6 +137,7 @@ def ledger_rows(app, invoice_value: str):
 def autofit_tree_columns(tree, cols, total_width=None):
     import tkinter.font as tkfont
     from tkinter import ttk
+    from .style import PADDING_X
 
     style = ttk.Style()
     font_name = style.lookup(tree.cget("style"), "font") or "TkDefaultFont"
@@ -152,8 +153,9 @@ def autofit_tree_columns(tree, cols, total_width=None):
             px = body_font.measure(txt)
             if px > max_px:
                 max_px = px
-        max_px = max(70, min(max_px + 24, 500))
-        widths.append(max_px)
+        max_px += PADDING_X * 4
+        max_px = max(70, min(max_px, 500))
+        widths.append(int(max_px))
 
     if total_width:
         total_content = sum(widths)
@@ -162,7 +164,7 @@ def autofit_tree_columns(tree, cols, total_width=None):
             widths = [w + extra for w in widths]
 
     for col, w in zip(cols, widths):
-        tree.column(col, width=w)
+        tree.column(col, width=w, minwidth=w)
 
 
 def populate_ledger_table(app, invoice_value: str):


### PR DESCRIPTION
## Oppsummering
- beregner kolonnebredder basert på skrifttypen som brukes i tabellen, slik at beløp vises uten avkutting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e7883dcc8328b858578ee10bcd70