### PR TITLE
Legg til DPI-basert skalering i GUI

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -7,6 +7,11 @@ from datetime import datetime
 
 from .style import style
 
+try:
+    from settings import UI_SCALING
+except Exception:  # pragma: no cover - valfri innstilling
+    UI_SCALING = None
+
 # CustomTkinter importeres ved behov for raskere oppstart.
 _ctk_mod = None
 
@@ -264,6 +269,9 @@ class App:
             return
         ctk.set_appearance_mode("system")
         ctk.set_default_color_theme("blue")
+        scale = UI_SCALING or (self.winfo_fpixels("1i") / 96)
+        ctk.set_widget_scaling(scale)
+        ctk.set_spacing_scaling(scale)
         self._theme_initialized = True
 
     def _switch_theme(self, mode):

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""Globale innstillinger for Bilagskontroll."""
+
+# Skaleringsfaktor for GUI. Sett til ``None`` for automatisk deteksjon.
+UI_SCALING = None


### PR DESCRIPTION
## Sammendrag
- Bruker `ctk.set_widget_scaling` og `ctk.set_spacing_scaling` for automatisk eller brukerdefinert skalering basert på DPI.
- Legger til `settings.py` med `UI_SCALING` for å kunne overstyre automatisk skalering.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2e88388048328b2adaeeb82120269