### PR TITLE
Skjul fremdriftslinje før bruk

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -699,7 +699,7 @@ class App:
             self.status_label.update_idletasks()
         if hasattr(self, "progress_bar"):
             if progress is not None:
-                self.progress_bar.grid()
+                self.progress_bar.grid(**getattr(self, "progress_bar_grid", {}))
                 self.progress_bar.set(max(0, min(1, progress / 100)))
                 self.progress_bar.update_idletasks()
             else:

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -169,14 +169,13 @@ def build_bottom(app):
         fg_color=style.get_color("bg"),
     )
     app.progress_bar.set(0)
-    app.progress_bar.grid(
-        row=0,
-        column=2,
-        padx=style.PAD_SM,
-        pady=style.PAD_SM,
-        sticky="e",
-    )
-    app.progress_bar.grid_remove()
+    app.progress_bar_grid = {
+        "row": 0,
+        "column": 2,
+        "padx": style.PAD_SM,
+        "pady": style.PAD_SM,
+        "sticky": "e",
+    }
 
     return bottom
 


### PR DESCRIPTION
## Sammendrag
- Utsetter plasseringen av fremdriftslinjen til den faktisk tas i bruk
- Oppdaterer _set_status slik at fremdriftslinjen vises med lagrede grid-parametre når fremdrift er tilgjengelig

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f44ba224832898ba02d7d75c61ba