### PR TITLE
Moderniser GUI med kort-baserte paneler

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -158,7 +158,7 @@ class App:
         if s.FONT_TITLE_LITE is None:
             s.FONT_TITLE_LITE = ctk.CTkFont(size=16, **kwargs)
         if s.FONT_TITLE_LARGE is None:
-            s.FONT_TITLE_LARGE = ctk.CTkFont(size=18, weight="bold", **kwargs)
+            s.FONT_TITLE_LARGE = ctk.CTkFont(size=19, weight="bold", **kwargs)
         if s.FONT_TITLE_SMALL is None:
             s.FONT_TITLE_SMALL = ctk.CTkFont(size=15, weight="bold", **kwargs)
         if s.FONT_BODY_BOLD is None:
@@ -167,6 +167,8 @@ class App:
             s.FONT_SMALL = ctk.CTkFont(size=13, **kwargs)
         if s.FONT_SMALL_ITALIC is None:
             s.FONT_SMALL_ITALIC = ctk.CTkFont(size=12, slant="italic", **kwargs)
+        if s.FONT_DISPLAY is None:
+            s.FONT_DISPLAY = ctk.CTkFont(size=22, weight="bold", **kwargs)
 
     def _ensure_helpers(self):
         """Importer tunge hjelpefunksjoner fra ``helpers`` ved første behov."""

--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -8,9 +8,9 @@ class DropZone(ctk.CTkFrame):
     """En ramme for dra-og-slipp med fargeendring ved drag hendelser."""
 
     def __init__(self, parent, text: str, drop_callback):
-        dnd_bg = style.get_color_pair("dnd_bg")
-        dnd_border = style.get_color_pair("dnd_border")
-        highlight = style.get_color_pair("success")
+        dnd_bg = style.get_color_pair("accent_soft")
+        dnd_border = style.get_color_pair("accent")
+        highlight = style.get_color_pair("accent")
 
         super().__init__(
             parent,
@@ -42,7 +42,7 @@ class DropZone(ctk.CTkFrame):
 
     def _on_drag_enter(self, _):
         self.configure(fg_color=self._highlight, border_color=self._highlight)
-        self.label.configure(text_color=style.get_color_pair("fg"))
+        self.label.configure(text_color=style.get_color_pair("bg"))
 
     def reset_colors(self, _=None):
         self.configure(fg_color=self._dnd_bg, border_color=self._dnd_border)

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -9,58 +9,149 @@ def build_header(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    head = ctk.CTkFrame(panel)
-    head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
-    head.grid_columnconfigure(6, weight=1)
-
-    head_font = style.FONT_TITLE_LITE
-
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.FONT_TITLE)
-    status_frame = ctk.CTkFrame(head, fg_color="transparent")
-    status_frame.grid(row=0, column=1, padx=style.PAD_MD, sticky="w")
-    app.lbl_status_label = ctk.CTkLabel(status_frame, text="Status:", font=head_font)
-    app.lbl_status_label.grid(row=0, column=0, padx=(0, style.PAD_XXS))
-    app.lbl_status = ctk.CTkLabel(
-        status_frame,
-        text="–",
-        font=head_font,
-        text_color=style.get_color("fg"),
+    head = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_card"),
+        border_width=1,
+        border_color=style.get_color("surface_border"),
     )
-    app.lbl_status.grid(row=0, column=1)
-    app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
-    app.lbl_count.grid(row=0, column=0, padx=(style.PAD_XS, style.PAD_LG))
-    app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
-    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
-    app.copy_feedback = ctk.CTkLabel(
+    head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
+    head.grid_columnconfigure(1, weight=1)
+
+    accent = ctk.CTkFrame(
         head,
+        width=style.PAD_MD,
+        fg_color=style.get_color("accent"),
+        corner_radius=style.CARD_RADIUS,
+    )
+    accent.grid(
+        row=0,
+        column=0,
+        rowspan=3,
+        sticky="ns",
+        padx=(style.PAD_MD, style.PAD_LG),
+        pady=style.PAD_LG,
+    )
+    accent.grid_propagate(False)
+
+    content = ctk.CTkFrame(head, fg_color="transparent")
+    content.grid(row=0, column=1, sticky="nsew", pady=(style.PAD_LG, style.PAD_MD))
+    content.grid_columnconfigure(0, weight=1)
+
+    title_row = ctk.CTkFrame(content, fg_color="transparent")
+    title_row.grid(row=0, column=0, sticky="ew", padx=(0, style.PAD_LG))
+    title_row.grid_columnconfigure(1, weight=1)
+    ctk.CTkLabel(
+        title_row,
+        text="Bilagskontroll",
+        font=style.FONT_DISPLAY,
+    ).grid(row=0, column=0, sticky="w")
+    ctk.CTkLabel(
+        title_row,
+        text="Profesjonell oversikt over bilagskontroll og status.",
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=1, column=0, sticky="w", pady=(style.PAD_XXS, 0))
+
+    metrics = ctk.CTkFrame(
+        content,
+        corner_radius=style.BTN_RADIUS,
+        fg_color=style.get_color("surface_muted"),
+    )
+    metrics.grid(
+        row=1,
+        column=0,
+        sticky="ew",
+        padx=(0, style.PAD_LG),
+        pady=(style.PAD_SM, 0),
+    )
+    metrics.grid_columnconfigure((0, 1, 2), weight=1)
+
+    def _stat_column(column: int, label: str, attr_name: str, default: str):
+        wrapper = ctk.CTkFrame(metrics, fg_color="transparent")
+        wrapper.grid(
+            row=0,
+            column=column,
+            sticky="nsew",
+            padx=style.PAD_SM,
+            pady=style.PAD_SM,
+        )
+        caption = ctk.CTkLabel(
+            wrapper,
+            text=label,
+            font=style.FONT_SMALL,
+            text_color=style.get_color("muted"),
+        )
+        caption.grid(row=0, column=0, sticky="w")
+        value_lbl = ctk.CTkLabel(wrapper, text=default, font=style.FONT_TITLE_LITE)
+        value_lbl.grid(row=1, column=0, sticky="w", pady=(style.PAD_XXS, 0))
+        setattr(app, attr_name, value_lbl)
+        if attr_name == "lbl_status":
+            app.lbl_status_label = caption
+        return wrapper
+
+    _stat_column(0, "Bilag", "lbl_count", "–/–")
+    _stat_column(1, "Fakturanr", "lbl_invoice", "–")
+    _stat_column(2, "Status", "lbl_status", "–")
+
+    feedback_row = ctk.CTkFrame(content, fg_color="transparent")
+    feedback_row.grid(
+        row=2,
+        column=0,
+        sticky="ew",
+        padx=(0, style.PAD_LG),
+        pady=(style.PAD_SM, 0),
+    )
+    feedback_row.grid_columnconfigure(2, weight=1)
+
+    create_button(
+        feedback_row,
+        text="📋 Kopier fakturanr",
+        command=app.copy_invoice,
+    ).grid(row=0, column=0, padx=(0, style.PAD_SM))
+    app.copy_feedback = ctk.CTkLabel(
+        feedback_row,
         text="",
         text_color=style.get_color("success"),
-        font=style.FONT_BODY,
+        font=style.FONT_SMALL,
     )
-    app.copy_feedback.grid(row=0, column=4, padx=style.PAD_MD, sticky="w")
+    app.copy_feedback.grid(row=0, column=1, padx=(0, style.PAD_SM), sticky="w")
 
     app.inline_status = ctk.CTkLabel(
-        head,
+        feedback_row,
         text="",
         text_color=style.get_color("success"),
-        font=style.FONT_BODY,
+        font=style.FONT_SMALL,
     )
-    app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
+    app.inline_status.grid(row=0, column=2, sticky="e")
 
-    ctk.CTkLabel(head, text="Temavalg", font=style.FONT_BODY).grid(
+    theme = ctk.CTkFrame(head, fg_color="transparent")
+    theme.grid(
         row=0,
-        column=7,
-        padx=(style.PAD_MD, style.PAD_XS),
+        column=2,
+        sticky="ne",
+        padx=(0, style.PAD_LG),
+        pady=(style.PAD_LG, style.PAD_MD),
     )
+    ctk.CTkLabel(
+        theme,
+        text="Tema",
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=0, column=0, sticky="w", pady=(0, style.PAD_XXS))
     default_theme_label = DEFAULT_APPEARANCE_MODE.title()
     app.theme_var = ctk.StringVar(value=default_theme_label)
     app.theme_menu = ctk.CTkOptionMenu(
-        head,
+        theme,
         variable=app.theme_var,
         values=["Light", "Dark"],
         command=app._switch_theme,
+        fg_color=style.get_color("surface_muted"),
+        button_color=style.get_color("accent"),
+        button_hover_color=style.get_color("accent"),
     )
-    app.theme_menu.grid(row=0, column=8, padx=(0, style.PAD_MD))
+    app.theme_menu.grid(row=1, column=0, sticky="ew")
     app.theme_menu.set(default_theme_label)
 
     return head
@@ -72,8 +163,32 @@ def build_action_buttons(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    btns = ctk.CTkFrame(panel)
-    btns.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
+    card = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_card"),
+        border_width=1,
+        border_color=style.get_color("surface_border"),
+    )
+    card.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
+    card.grid_columnconfigure(0, weight=1)
+
+    ctk.CTkLabel(card, text="Handlinger", font=style.FONT_TITLE_SMALL).grid(
+        row=0,
+        column=0,
+        sticky="w",
+        padx=style.PAD_LG,
+        pady=(style.PAD_MD, style.PAD_XS),
+    )
+    ctk.CTkLabel(
+        card,
+        text="Velg ønsket handling for neste bilag.",
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=1, column=0, sticky="w", padx=style.PAD_LG, pady=(0, style.PAD_SM))
+
+    btns = ctk.CTkFrame(card, fg_color="transparent")
+    btns.grid(row=2, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_SM))
     btns.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
 
     create_button(
@@ -90,13 +205,17 @@ def build_action_buttons(app):
         hover_color=style.get_color("error_hover"),
         command=lambda: app.set_decision_and_next("Ikke godkjent"),
     ).grid(row=0, column=1, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    create_button(btns, text="🔗 Åpne PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    create_button(
+        btns,
+        text="🔗 Åpne PowerOffice",
+        command=app.open_in_po,
+    ).grid(row=0, column=2, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
     app.btn_prev = create_button(btns, text="⬅ Forrige", command=app.prev)
     app.btn_prev.grid(row=0, column=3, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
     app.btn_next = create_button(btns, text="➡ Neste", command=app.next)
     app.btn_next.grid(row=0, column=4, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
 
-    return btns
+    return card
 
 
 def build_panes(app):
@@ -105,41 +224,96 @@ def build_panes(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    paned = ctk.CTkFrame(panel)
+    paned = ctk.CTkFrame(panel, fg_color="transparent")
     paned.grid(row=2, column=0, sticky="nsew", padx=style.PAD_LG, pady=(style.PAD_XS, style.PAD_SM))
     paned.grid_columnconfigure((0, 1), weight=1, minsize=400)
     paned.grid_rowconfigure(0, weight=1)
 
-    left = ctk.CTkFrame(paned)
-    right = ctk.CTkFrame(paned)
-    left.grid(row=0, column=0, sticky="nsew")
-    right.grid(row=0, column=1, sticky="nsew")
+    left = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_card"),
+        border_width=1,
+        border_color=style.get_color("surface_border"),
+    )
+    right = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_card"),
+        border_width=1,
+        border_color=style.get_color("surface_border"),
+    )
+    left.grid(row=0, column=0, sticky="nsew", padx=(0, style.PAD_SM))
+    right.grid(row=0, column=1, sticky="nsew", padx=(style.PAD_SM, 0))
     app.right_frame = right
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
-    app.detail_box = ctk.CTkTextbox(left, height=360, font=style.FONT_BODY)
-    app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(style.PAD_MD, style.PAD_SM), pady=(0, style.PAD_MD))
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    left_header = ctk.CTkFrame(left, fg_color="transparent")
+    left_header.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=(style.PAD_MD, style.PAD_XS))
+    ctk.CTkLabel(left_header, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL).grid(
+        row=0,
+        column=0,
+        sticky="w",
+    )
+    app.detail_box = ctk.CTkTextbox(
+        left,
+        height=360,
+        font=style.FONT_BODY,
+        fg_color=style.get_color("surface_muted"),
+        text_color=style.get_color("fg"),
+        corner_radius=style.BTN_RADIUS,
+        border_width=0,
+    )
+    app.detail_box.grid(
+        row=1,
+        column=0,
+        sticky="nsew",
+        padx=(style.PAD_LG, style.PAD_LG),
+        pady=(0, style.PAD_LG),
+    )
+
     right.grid_columnconfigure(0, weight=1)
     right.grid_columnconfigure(1, weight=0)
     right.grid_rowconfigure(1, weight=3, minsize=150)
     right.grid_rowconfigure(5, weight=1, minsize=120)
 
-    ctk.CTkLabel(right, text="Kommentar", font=style.FONT_TITLE_SMALL)\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(style.PAD_MD, style.PAD_SM), pady=(style.PAD_MD, style.PAD_XS))
-    app.comment_box = ctk.CTkTextbox(right, font=style.FONT_SMALL)
+    right_header = ctk.CTkFrame(right, fg_color="transparent")
+    right_header.grid(row=0, column=0, columnspan=2, sticky="ew", padx=style.PAD_LG, pady=(style.PAD_MD, style.PAD_XS))
+    ctk.CTkLabel(
+        right_header,
+        text="Hovedbok (bilagslinjer)",
+        font=style.FONT_TITLE_SMALL,
+    ).grid(row=0, column=0, sticky="w")
+
+    ctk.CTkLabel(
+        right,
+        text="Kommentar",
+        font=style.FONT_TITLE_SMALL,
+    ).grid(
+        row=4,
+        column=0,
+        columnspan=2,
+        sticky="w",
+        padx=(style.PAD_LG, style.PAD_LG),
+        pady=(style.PAD_MD, style.PAD_XS),
+    )
+    app.comment_box = ctk.CTkTextbox(
+        right,
+        font=style.FONT_SMALL,
+        fg_color=style.get_color("surface_muted"),
+        text_color=style.get_color("fg"),
+        corner_radius=style.BTN_RADIUS,
+        border_width=0,
+    )
     app.comment_box.grid(
         row=5,
         column=0,
         columnspan=2,
         sticky="nsew",
-        padx=(style.PAD_MD, style.PAD_SM),
-        pady=(0, style.PAD_MD),
+        padx=(style.PAD_LG, style.PAD_LG),
+        pady=(0, style.PAD_LG),
     )
 
     return paned
@@ -151,10 +325,20 @@ def build_bottom(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    bottom = ctk.CTkFrame(panel)
+    bottom = ctk.CTkFrame(panel, fg_color="transparent")
     bottom.grid(row=3, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_MD))
-    bottom.grid_columnconfigure(1, weight=1)
+    bottom.grid_columnconfigure(0, weight=1)
     app.bottom_frame = bottom
+
+    card = ctk.CTkFrame(
+        bottom,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_card"),
+        border_width=1,
+        border_color=style.get_color("surface_border"),
+    )
+    card.grid(row=0, column=0, sticky="ew")
+    card.grid_columnconfigure(2, weight=1)
 
     def _export_pdf():
         from report import export_pdf
@@ -176,30 +360,35 @@ def build_bottom(app):
         run_in_thread(worker)
 
     export_btn = create_button(
-        bottom, text="📄 Eksporter PDF rapport", command=_export_pdf
+        card, text="📄 Eksporter PDF rapport", command=_export_pdf
     )
     export_btn.grid(
         row=0,
         column=0,
-        padx=(style.PAD_MD, style.PAD_SM),
-        pady=style.PAD_SM,
+        padx=(style.PAD_LG, style.PAD_SM),
+        pady=(style.PAD_MD, style.PAD_SM),
         sticky="w",
     )
 
-    app.status_label = ctk.CTkLabel(bottom, text="", font=style.FONT_BODY)
+    app.status_label = ctk.CTkLabel(
+        card,
+        text="",
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    )
     app.status_label.grid(
         row=0,
         column=1,
-        padx=style.PAD_SM,
-        pady=style.PAD_SM,
-        sticky="ew",
+        padx=(0, style.PAD_SM),
+        pady=(style.PAD_MD, style.PAD_SM),
+        sticky="w",
     )
 
     app.progress_bar = ctk.CTkProgressBar(
-        bottom,
-        width=120,
+        card,
+        width=160,
         progress_color=style.get_color("success"),
-        fg_color=style.get_color("bg"),
+        fg_color=style.get_color("surface_muted"),
     )
     app.progress_bar.set(0)
     app.progress_bar_grid = {
@@ -218,7 +407,11 @@ def build_main(app):
 
     import customtkinter as ctk
 
-    panel = ctk.CTkFrame(app, corner_radius=16)
+    panel = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_muted"),
+    )
     panel.grid(row=0, column=1, sticky="nsew", padx=(0, style.PAD_XL), pady=style.PAD_XL)
     panel.grid_columnconfigure(0, weight=1)
     panel.grid_rowconfigure(2, weight=1, minsize=300)
@@ -262,9 +455,32 @@ def build_ledger_widgets(app):
     )
 
     right = app.right_frame
+    right.grid_columnconfigure(0, weight=1)
+    right.grid_columnconfigure(1, weight=0)
+
+    table_container = ctk.CTkFrame(
+        right,
+        corner_radius=style.BTN_RADIUS,
+        fg_color=style.get_color("surface_muted"),
+    )
+    table_container.grid(
+        row=1,
+        column=0,
+        columnspan=2,
+        sticky="nsew",
+        padx=(style.PAD_LG, style.PAD_LG),
+        pady=(0, style.PAD_SM),
+    )
+    table_container.grid_columnconfigure(0, weight=1)
+    table_container.grid_rowconfigure(0, weight=1)
+
     app.ledger_cols = LEDGER_COLS
     app.ledger_tree = ttk.Treeview(
-        right, columns=LEDGER_COLS, show="headings", height=10, style="Custom.Treeview"
+        table_container,
+        columns=LEDGER_COLS,
+        show="headings",
+        height=10,
+        style="Custom.Treeview",
     )
     for col, w, anchor in [
         ("Kontonr", 90, "w"),
@@ -282,12 +498,12 @@ def build_ledger_widgets(app):
         )
         app.ledger_tree.column(col, width=w, minwidth=60, anchor=anchor, stretch=True)
 
-    yscroll = ctk.CTkScrollbar(right, orientation="vertical", command=app.ledger_tree.yview)
-    xscroll = ctk.CTkScrollbar(right, orientation="horizontal", command=app.ledger_tree.xview)
+    yscroll = ctk.CTkScrollbar(table_container, orientation="vertical", command=app.ledger_tree.yview)
+    xscroll = ctk.CTkScrollbar(table_container, orientation="horizontal", command=app.ledger_tree.xview)
     app.ledger_tree.configure(yscrollcommand=yscroll.set, xscrollcommand=xscroll.set)
-    app.ledger_tree.grid(row=1, column=0, sticky="nsew")
-    yscroll.grid(row=1, column=1, sticky="ns")
-    xscroll.grid(row=2, column=0, sticky="ew")
+    app.ledger_tree.grid(row=0, column=0, sticky="nsew", padx=(style.PAD_SM, 0), pady=(style.PAD_SM, 0))
+    yscroll.grid(row=0, column=1, sticky="ns", pady=style.PAD_SM, padx=(style.PAD_XXS, style.PAD_XXS))
+    xscroll.grid(row=1, column=0, sticky="ew", padx=(style.PAD_SM, style.PAD_SM), pady=(style.PAD_XXS, style.PAD_SM))
 
     app._prev_ledger_width = None
     app._ledger_configure_id = app.ledger_tree.bind(
@@ -306,12 +522,13 @@ def build_ledger_widgets(app):
         anchor="e",
         justify="right",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     )
     app.ledger_sum.grid(
         row=3,
         column=0,
         columnspan=2,
         sticky="ew",
-        padx=(0, style.PAD_LG),
+        padx=(style.PAD_LG, style.PAD_LG),
         pady=(style.PAD_SM, PADDING_Y),
     )

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -12,9 +12,9 @@ def build_header(app):
     head = ctk.CTkFrame(
         panel,
         corner_radius=style.CARD_RADIUS,
-        fg_color=style.get_color("surface_card"),
+        fg_color=style.get_color_pair("surface_card"),
         border_width=1,
-        border_color=style.get_color("surface_border"),
+        border_color=style.get_color_pair("surface_border"),
     )
     head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
     head.grid_columnconfigure(1, weight=1)
@@ -22,7 +22,7 @@ def build_header(app):
     accent = ctk.CTkFrame(
         head,
         width=style.PAD_MD,
-        fg_color=style.get_color("accent"),
+        fg_color=style.get_color_pair("accent"),
         corner_radius=style.CARD_RADIUS,
     )
     accent.grid(
@@ -51,13 +51,13 @@ def build_header(app):
         title_row,
         text="Profesjonell oversikt over bilagskontroll og status.",
         font=style.FONT_SMALL,
-        text_color=style.get_color("muted"),
+        text_color=style.get_color_pair("muted"),
     ).grid(row=1, column=0, sticky="w", pady=(style.PAD_XXS, 0))
 
     metrics = ctk.CTkFrame(
         content,
         corner_radius=style.BTN_RADIUS,
-        fg_color=style.get_color("surface_muted"),
+        fg_color=style.get_color_pair("surface_muted"),
     )
     metrics.grid(
         row=1,
@@ -81,7 +81,7 @@ def build_header(app):
             wrapper,
             text=label,
             font=style.FONT_SMALL,
-            text_color=style.get_color("muted"),
+            text_color=style.get_color_pair("muted"),
         )
         caption.grid(row=0, column=0, sticky="w")
         value_lbl = ctk.CTkLabel(wrapper, text=default, font=style.FONT_TITLE_LITE)
@@ -113,7 +113,7 @@ def build_header(app):
     app.copy_feedback = ctk.CTkLabel(
         feedback_row,
         text="",
-        text_color=style.get_color("success"),
+        text_color=style.get_color_pair("success"),
         font=style.FONT_SMALL,
     )
     app.copy_feedback.grid(row=0, column=1, padx=(0, style.PAD_SM), sticky="w")
@@ -121,7 +121,7 @@ def build_header(app):
     app.inline_status = ctk.CTkLabel(
         feedback_row,
         text="",
-        text_color=style.get_color("success"),
+        text_color=style.get_color_pair("success"),
         font=style.FONT_SMALL,
     )
     app.inline_status.grid(row=0, column=2, sticky="e")
@@ -138,7 +138,7 @@ def build_header(app):
         theme,
         text="Tema",
         font=style.FONT_SMALL,
-        text_color=style.get_color("muted"),
+        text_color=style.get_color_pair("muted"),
     ).grid(row=0, column=0, sticky="w", pady=(0, style.PAD_XXS))
     default_theme_label = DEFAULT_APPEARANCE_MODE.title()
     app.theme_var = ctk.StringVar(value=default_theme_label)
@@ -147,9 +147,9 @@ def build_header(app):
         variable=app.theme_var,
         values=["Light", "Dark"],
         command=app._switch_theme,
-        fg_color=style.get_color("surface_muted"),
-        button_color=style.get_color("accent"),
-        button_hover_color=style.get_color("accent"),
+        fg_color=style.get_color_pair("surface_muted"),
+        button_color=style.get_color_pair("accent"),
+        button_hover_color=style.get_color_pair("accent"),
     )
     app.theme_menu.grid(row=1, column=0, sticky="ew")
     app.theme_menu.set(default_theme_label)
@@ -166,9 +166,9 @@ def build_action_buttons(app):
     card = ctk.CTkFrame(
         panel,
         corner_radius=style.CARD_RADIUS,
-        fg_color=style.get_color("surface_card"),
+        fg_color=style.get_color_pair("surface_card"),
         border_width=1,
-        border_color=style.get_color("surface_border"),
+        border_color=style.get_color_pair("surface_border"),
     )
     card.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
     card.grid_columnconfigure(0, weight=1)
@@ -184,7 +184,7 @@ def build_action_buttons(app):
         card,
         text="Velg ønsket handling for neste bilag.",
         font=style.FONT_SMALL,
-        text_color=style.get_color("muted"),
+        text_color=style.get_color_pair("muted"),
     ).grid(row=1, column=0, sticky="w", padx=style.PAD_LG, pady=(0, style.PAD_SM))
 
     btns = ctk.CTkFrame(card, fg_color="transparent")
@@ -194,15 +194,15 @@ def build_action_buttons(app):
     create_button(
         btns,
         text="✅ Godkjent",
-        fg_color=style.get_color("success"),
-        hover_color=style.get_color("success_hover"),
+        fg_color=style.get_color_pair("success"),
+        hover_color=style.get_color_pair("success_hover"),
         command=lambda: app.set_decision_and_next("Godkjent"),
     ).grid(row=0, column=0, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
     create_button(
         btns,
         text="⛔ Ikke godkjent",
-        fg_color=style.get_color("error"),
-        hover_color=style.get_color("error_hover"),
+        fg_color=style.get_color_pair("error"),
+        hover_color=style.get_color_pair("error_hover"),
         command=lambda: app.set_decision_and_next("Ikke godkjent"),
     ).grid(row=0, column=1, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
     create_button(
@@ -232,16 +232,16 @@ def build_panes(app):
     left = ctk.CTkFrame(
         paned,
         corner_radius=style.CARD_RADIUS,
-        fg_color=style.get_color("surface_card"),
+        fg_color=style.get_color_pair("surface_card"),
         border_width=1,
-        border_color=style.get_color("surface_border"),
+        border_color=style.get_color_pair("surface_border"),
     )
     right = ctk.CTkFrame(
         paned,
         corner_radius=style.CARD_RADIUS,
-        fg_color=style.get_color("surface_card"),
+        fg_color=style.get_color_pair("surface_card"),
         border_width=1,
-        border_color=style.get_color("surface_border"),
+        border_color=style.get_color_pair("surface_border"),
     )
     left.grid(row=0, column=0, sticky="nsew", padx=(0, style.PAD_SM))
     right.grid(row=0, column=1, sticky="nsew", padx=(style.PAD_SM, 0))
@@ -261,8 +261,8 @@ def build_panes(app):
         left,
         height=360,
         font=style.FONT_BODY,
-        fg_color=style.get_color("surface_muted"),
-        text_color=style.get_color("fg"),
+        fg_color=style.get_color_pair("surface_muted"),
+        text_color=style.get_color_pair("fg"),
         corner_radius=style.BTN_RADIUS,
         border_width=0,
     )
@@ -302,8 +302,8 @@ def build_panes(app):
     app.comment_box = ctk.CTkTextbox(
         right,
         font=style.FONT_SMALL,
-        fg_color=style.get_color("surface_muted"),
-        text_color=style.get_color("fg"),
+        fg_color=style.get_color_pair("surface_muted"),
+        text_color=style.get_color_pair("fg"),
         corner_radius=style.BTN_RADIUS,
         border_width=0,
     )
@@ -333,9 +333,9 @@ def build_bottom(app):
     card = ctk.CTkFrame(
         bottom,
         corner_radius=style.CARD_RADIUS,
-        fg_color=style.get_color("surface_card"),
+        fg_color=style.get_color_pair("surface_card"),
         border_width=1,
-        border_color=style.get_color("surface_border"),
+        border_color=style.get_color_pair("surface_border"),
     )
     card.grid(row=0, column=0, sticky="ew")
     card.grid_columnconfigure(2, weight=1)
@@ -374,7 +374,7 @@ def build_bottom(app):
         card,
         text="",
         font=style.FONT_SMALL,
-        text_color=style.get_color("muted"),
+        text_color=style.get_color_pair("muted"),
     )
     app.status_label.grid(
         row=0,
@@ -387,8 +387,8 @@ def build_bottom(app):
     app.progress_bar = ctk.CTkProgressBar(
         card,
         width=160,
-        progress_color=style.get_color("success"),
-        fg_color=style.get_color("surface_muted"),
+        progress_color=style.get_color_pair("success"),
+        fg_color=style.get_color_pair("surface_muted"),
     )
     app.progress_bar.set(0)
     app.progress_bar_grid = {
@@ -410,7 +410,7 @@ def build_main(app):
     panel = ctk.CTkFrame(
         app,
         corner_radius=style.CARD_RADIUS,
-        fg_color=style.get_color("surface_muted"),
+        fg_color=style.get_color_pair("surface_muted"),
     )
     panel.grid(row=0, column=1, sticky="nsew", padx=(0, style.PAD_XL), pady=style.PAD_XL)
     panel.grid_columnconfigure(0, weight=1)
@@ -461,7 +461,7 @@ def build_ledger_widgets(app):
     table_container = ctk.CTkFrame(
         right,
         corner_radius=style.BTN_RADIUS,
-        fg_color=style.get_color("surface_muted"),
+        fg_color=style.get_color_pair("surface_muted"),
     )
     table_container.grid(
         row=1,
@@ -522,7 +522,7 @@ def build_ledger_widgets(app):
         anchor="e",
         justify="right",
         font=style.FONT_BODY,
-        text_color=style.get_color("muted"),
+        text_color=style.get_color_pair("muted"),
     )
     app.ledger_sum.grid(
         row=3,

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -27,15 +27,36 @@ def _toggle_sample_btn(app, *_):
 def build_sidebar(app):
     import customtkinter as ctk
 
-    card = ctk.CTkFrame(app, corner_radius=16)
+    card = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_card"),
+        border_width=1,
+        border_color=style.get_color("surface_border"),
+    )
     card.grid(row=0, column=0, sticky="nsw", padx=style.PAD_XL, pady=style.PAD_XL)
 
-    ctk.CTkLabel(card, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE)\
-        .grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
+    header = ctk.CTkFrame(card, fg_color="transparent")
+    header.grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="ew")
+    header.grid_columnconfigure(0, weight=1)
+    ctk.CTkLabel(header, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE).grid(
+        row=0,
+        column=0,
+        sticky="w",
+    )
+    ctk.CTkLabel(
+        header,
+        text="Last opp og tilpass grunnlaget for kontrollen.",
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=1, column=0, sticky="w", pady=(style.PAD_XXS, 0))
 
     app.file_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
-        .grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
+    create_button(
+        card,
+        text="Velg leverandørfakturaer (Excel)…",
+        command=app.choose_file,
+    ).grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
     def _drop_invoice(event):
         path = parse_dropped_path(event)
         if not path:
@@ -55,8 +76,11 @@ def build_sidebar(app):
     ).grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
-        .grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
+    create_button(
+        card,
+        text="Velg hovedbok (Excel)…",
+        command=app.choose_gl_file,
+    ).grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
 
     def _drop_gl(event):
         path = parse_dropped_path(event)
@@ -79,7 +103,7 @@ def build_sidebar(app):
     app.add_drop_target(app.inv_drop, app.inv_drop.on_drop)
     app.add_drop_target(app.gl_drop, app.gl_drop.on_drop)
 
-    row_utv = ctk.CTkFrame(card)
+    row_utv = ctk.CTkFrame(card, fg_color="transparent")
     row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")
     ctk.CTkLabel(row_utv, text="Antall tilfeldig utvalg", font=style.FONT_BODY).grid(
         row=0, column=0, padx=(style.PAD_MD, 0), sticky="w"
@@ -117,7 +141,12 @@ def build_sidebar(app):
     )
     app.year_combo.grid(row=1, column=1, padx=(style.PAD_MD, 0), pady=(style.PAD_SM, 0))
 
-    app.sample_btn = create_button(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
+    app.sample_btn = create_button(
+        card,
+        text="🎲 Lag utvalg",
+        command=app.make_sample,
+        state="disabled",
+    )
     app.sample_btn.grid(row=8, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_SM), sticky="ew")
 
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
@@ -126,9 +155,18 @@ def build_sidebar(app):
     app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=style.FONT_TITLE)
     app.lbl_filecount.grid(row=9, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="w")
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.FONT_BODY_BOLD)\
-        .grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
-    opp = ctk.CTkFrame(card, corner_radius=8)
+    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.FONT_BODY_BOLD).grid(
+        row=10,
+        column=0,
+        padx=style.PAD_XL,
+        pady=(style.PAD_MD, style.PAD_XXS),
+        sticky="w",
+    )
+    opp = ctk.CTkFrame(
+        card,
+        corner_radius=style.BTN_RADIUS,
+        fg_color=style.get_color("surface_muted"),
+    )
     opp.grid(row=11, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
     opp.grid_columnconfigure(0, weight=0)
     opp.grid_columnconfigure(1, weight=1)
@@ -163,15 +201,27 @@ def build_sidebar(app):
         opp,
         text="Kundenavn hentes automatisk",
         font=style.FONT_SMALL_ITALIC,
+        text_color=style.get_color("muted"),
         anchor="w",
         justify="left",
         wraplength=240,
     )
-    info_lbl.grid(row=2, column=0, columnspan=2, padx=(style.PAD_MD, style.PAD_MD), pady=(0, style.PAD_MD), sticky="w")
+    info_lbl.grid(
+        row=2,
+        column=0,
+        columnspan=2,
+        padx=(style.PAD_MD, style.PAD_MD),
+        pady=(0, style.PAD_MD),
+        sticky="w",
+    )
 
     card.grid_rowconfigure(20, weight=1)
 
-    status_card = ctk.CTkFrame(card, corner_radius=12)
+    status_card = ctk.CTkFrame(
+        card,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("accent_soft"),
+    )
     status_card.grid(
         row=100,
         column=0,
@@ -184,19 +234,48 @@ def build_sidebar(app):
     title_font = style.FONT_TITLE_LARGE
     body_font = style.FONT_BODY
 
-    ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
-        .grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
+    ctk.CTkLabel(
+        status_card,
+        text="Status",
+        font=title_font,
+        anchor="center",
+        justify="center",
+    ).grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
 
-    app.lbl_st_sum_kontrollert = ctk.CTkLabel(status_card, text="Sum kontrollert: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_kontrollert = ctk.CTkLabel(
+        status_card,
+        text="Sum kontrollert: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_sum_kontrollert.grid(row=1, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_sum_alle = ctk.CTkLabel(status_card, text="Sum alle bilag: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_alle = ctk.CTkLabel(
+        status_card,
+        text="Sum alle bilag: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_sum_alle.grid(row=2, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_pct = ctk.CTkLabel(status_card, text="% kontrollert av sum: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_pct = ctk.CTkLabel(
+        status_card,
+        text="% kontrollert av sum: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_pct.grid(row=3, column=0, sticky="ew", pady=(0, style.PAD_MD))
 
-    app.lbl_st_godkjent = ctk.CTkLabel(status_card, text="Godkjent: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_godkjent = ctk.CTkLabel(
+        status_card,
+        text="Godkjent: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_godkjent.grid(row=4, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
     app.lbl_st_ikkegodkjent = ctk.CTkLabel(status_card, text="Ikke godkjent: –", font=body_font, anchor="center", justify="center")

--- a/gui/style.py
+++ b/gui/style.py
@@ -12,9 +12,10 @@ class Style:
     """Samler felles stilkonfigurasjon for GUI."""
 
     # Knappestil
-    BTN_FG: str = "#1f6aa5"
-    BTN_HOVER: str = "#185a8b"
+    BTN_FG: str = "#2467c9"
+    BTN_HOVER: str = "#1b55a3"
     BTN_RADIUS: int = 8
+    CARD_RADIUS: int = 14
 
     # Farger per tema
     COLORS: Dict[str, Dict[str, str]] = field(
@@ -37,6 +38,13 @@ class Style:
             "table_sel_fg": {"light": "#000000", "dark": "#ffffff"},
             "table_row_odd": {"light": "#f6f6f6", "dark": "#232323"},
             "table_row_even": {"light": "#ffffff", "dark": "#1e1e1e"},
+            # Flater
+            "surface_card": {"light": "#f9fafc", "dark": "#23242a"},
+            "surface_muted": {"light": "#eef2f7", "dark": "#2c2f36"},
+            "surface_border": {"light": "#d5dbe7", "dark": "#3b3f47"},
+            "muted": {"light": "#5f6b7a", "dark": "#b0b5c0"},
+            "accent": {"light": "#2467c9", "dark": "#7aa8ff"},
+            "accent_soft": {"light": "#d9e5fb", "dark": "#2d3c55"},
         }
     )
 
@@ -69,6 +77,7 @@ class Style:
     FONT_BODY_BOLD: Optional[object] = None
     FONT_SMALL: Optional[object] = None
     FONT_SMALL_ITALIC: Optional[object] = None
+    FONT_DISPLAY: Optional[object] = None
 
     # Standard spacing
     PAD_XL: int = 14


### PR DESCRIPTION
## Sammendrag
- introduserer ny fargepalett, kort-radius og display-font for et mer profesjonelt uttrykk
- redesigner hovedpanelet med hero-header, kort for handlinger og nye seksjoner for detaljer og hovedbok
- oppdaterer sidepanelet og dropzoner med matchende fargetoner og forbedret mikrotypografi

## Tester
- pytest *(feiler: mangler avhengighetene pandas og openpyxl i miljøet)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5c71f41883288c29482bb0a4e5c9