### PR TITLE
Moderniser GUI-stilen for mer profesjonelt uttrykk

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -61,6 +61,8 @@ def create_button(master, **kwargs):
         "hover_color": style.BTN_HOVER,
         "font": style.FONT_BODY,
         "corner_radius": style.BTN_RADIUS,
+        "text_color": style.get_color("button_text"),
+        "text_color_disabled": style.get_color("muted"),
     }
     options.update(kwargs)
     return ctk.CTkButton(master, **options)
@@ -152,19 +154,19 @@ class App:
         s = style
         kwargs = {"family": s.FONT_FAMILY}
         if s.FONT_TITLE is None:
-            s.FONT_TITLE = ctk.CTkFont(size=16, weight="bold", **kwargs)
+            s.FONT_TITLE = ctk.CTkFont(size=17, weight="bold", **kwargs)
         if s.FONT_BODY is None:
             s.FONT_BODY = ctk.CTkFont(size=14, **kwargs)
         if s.FONT_TITLE_LITE is None:
             s.FONT_TITLE_LITE = ctk.CTkFont(size=16, **kwargs)
         if s.FONT_TITLE_LARGE is None:
-            s.FONT_TITLE_LARGE = ctk.CTkFont(size=18, weight="bold", **kwargs)
+            s.FONT_TITLE_LARGE = ctk.CTkFont(size=20, weight="bold", **kwargs)
         if s.FONT_TITLE_SMALL is None:
             s.FONT_TITLE_SMALL = ctk.CTkFont(size=15, weight="bold", **kwargs)
         if s.FONT_BODY_BOLD is None:
             s.FONT_BODY_BOLD = ctk.CTkFont(size=14, weight="bold", **kwargs)
         if s.FONT_SMALL is None:
-            s.FONT_SMALL = ctk.CTkFont(size=13, **kwargs)
+            s.FONT_SMALL = ctk.CTkFont(size=12, **kwargs)
         if s.FONT_SMALL_ITALIC is None:
             s.FONT_SMALL_ITALIC = ctk.CTkFont(size=12, slant="italic", **kwargs)
 
@@ -214,6 +216,7 @@ class App:
         self.grid_columnconfigure(0, weight=0)
         self.grid_columnconfigure(1, weight=1)
         self.grid_rowconfigure(0, weight=1)
+        self.configure(fg_color=style.get_color("background"))
 
         self.bind("<Left>", lambda e: self.prev())
         self.bind("<Right>", lambda e: self.next())

--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -10,15 +10,15 @@ class DropZone(ctk.CTkFrame):
     def __init__(self, parent, text: str, drop_callback):
         dnd_bg = style.get_color_pair("dnd_bg")
         dnd_border = style.get_color_pair("dnd_border")
-        highlight = style.get_color_pair("success")
+        highlight = style.get_color_pair("accent")
 
         super().__init__(
             parent,
             height=70,
-            corner_radius=style.BTN_RADIUS,
+            corner_radius=style.CARD_RADIUS,
             fg_color=dnd_bg,
             border_color=dnd_border,
-            border_width=2,
+            border_width=style.OUTLINE_WIDTH,
         )
 
         self._dnd_bg = dnd_bg
@@ -32,6 +32,7 @@ class DropZone(ctk.CTkFrame):
             text=text,
             anchor="center",
             text_color=self._label_text_color,
+            font=style.FONT_BODY,
         )
         self.label.pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
 

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -9,16 +9,32 @@ def build_header(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    head = ctk.CTkFrame(panel)
+    head = ctk.CTkFrame(
+        panel,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
     head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
     head.grid_columnconfigure(6, weight=1)
 
     head_font = style.FONT_TITLE_LITE
 
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.FONT_TITLE)
+    app.lbl_count = ctk.CTkLabel(
+        head,
+        text="Bilag: –/–",
+        font=style.FONT_TITLE,
+        text_color=style.get_color("fg"),
+    )
     status_frame = ctk.CTkFrame(head, fg_color="transparent")
     status_frame.grid(row=0, column=1, padx=style.PAD_MD, sticky="w")
-    app.lbl_status_label = ctk.CTkLabel(status_frame, text="Status:", font=head_font)
+    app.lbl_status_label = ctk.CTkLabel(
+        status_frame,
+        text="Status:",
+        font=head_font,
+        text_color=style.get_color("muted"),
+    )
     app.lbl_status_label.grid(row=0, column=0, padx=(0, style.PAD_XXS))
     app.lbl_status = ctk.CTkLabel(
         status_frame,
@@ -27,10 +43,17 @@ def build_header(app):
         text_color=style.get_color("fg"),
     )
     app.lbl_status.grid(row=0, column=1)
-    app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
+    app.lbl_invoice = ctk.CTkLabel(
+        head,
+        text="Fakturanr: –",
+        font=head_font,
+        text_color=style.get_color("muted"),
+    )
     app.lbl_count.grid(row=0, column=0, padx=(style.PAD_XS, style.PAD_LG))
     app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
-    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
+    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(
+        row=0, column=3, padx=(style.PAD_MD, 0)
+    )
     app.copy_feedback = ctk.CTkLabel(
         head,
         text="",
@@ -47,7 +70,12 @@ def build_header(app):
     )
     app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
 
-    ctk.CTkLabel(head, text="Temavalg", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        head,
+        text="Temavalg",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=0,
         column=7,
         padx=(style.PAD_MD, style.PAD_XS),
@@ -72,8 +100,14 @@ def build_action_buttons(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    btns = ctk.CTkFrame(panel)
-    btns.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
+    btns = ctk.CTkFrame(
+        panel,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
+    btns.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_SM))
     btns.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
 
     create_button(
@@ -105,34 +139,93 @@ def build_panes(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    paned = ctk.CTkFrame(panel)
-    paned.grid(row=2, column=0, sticky="nsew", padx=style.PAD_LG, pady=(style.PAD_XS, style.PAD_SM))
+    paned = ctk.CTkFrame(
+        panel,
+        fg_color="transparent",
+    )
+    paned.grid(
+        row=2,
+        column=0,
+        sticky="nsew",
+        padx=style.PAD_LG,
+        pady=(style.PAD_XS, style.PAD_SM),
+    )
     paned.grid_columnconfigure((0, 1), weight=1, minsize=400)
     paned.grid_rowconfigure(0, weight=1)
 
-    left = ctk.CTkFrame(paned)
-    right = ctk.CTkFrame(paned)
-    left.grid(row=0, column=0, sticky="nsew")
-    right.grid(row=0, column=1, sticky="nsew")
+    left = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
+    right = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
+    left.grid(row=0, column=0, sticky="nsew", padx=(0, style.PAD_SM))
+    right.grid(row=0, column=1, sticky="nsew", padx=(style.PAD_SM, 0))
     app.right_frame = right
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    ctk.CTkLabel(
+        left,
+        text="Detaljer for bilag",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
-    app.detail_box = ctk.CTkTextbox(left, height=360, font=style.FONT_BODY)
-    app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(style.PAD_MD, style.PAD_SM), pady=(0, style.PAD_MD))
+    app.detail_box = ctk.CTkTextbox(
+        left,
+        height=360,
+        font=style.FONT_BODY,
+        fg_color=style.get_color("surface_alt"),
+        text_color=style.get_color("fg"),
+        corner_radius=style.SECTION_RADIUS,
+    )
+    app.detail_box.grid(
+        row=1,
+        column=0,
+        sticky="nsew",
+        padx=(style.PAD_MD, style.PAD_SM),
+        pady=(0, style.PAD_MD),
+    )
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    ctk.CTkLabel(
+        right,
+        text="Hovedbok (bilagslinjer)",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
     right.grid_columnconfigure(0, weight=1)
     right.grid_columnconfigure(1, weight=0)
     right.grid_rowconfigure(1, weight=3, minsize=150)
     right.grid_rowconfigure(5, weight=1, minsize=120)
 
-    ctk.CTkLabel(right, text="Kommentar", font=style.FONT_TITLE_SMALL)\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(style.PAD_MD, style.PAD_SM), pady=(style.PAD_MD, style.PAD_XS))
-    app.comment_box = ctk.CTkTextbox(right, font=style.FONT_SMALL)
+    ctk.CTkLabel(
+        right,
+        text="Kommentar",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(
+        row=4,
+        column=0,
+        columnspan=2,
+        sticky="w",
+        padx=(style.PAD_MD, style.PAD_SM),
+        pady=(style.PAD_MD, style.PAD_XS),
+    )
+    app.comment_box = ctk.CTkTextbox(
+        right,
+        font=style.FONT_SMALL,
+        fg_color=style.get_color("surface_alt"),
+        text_color=style.get_color("fg"),
+        corner_radius=style.SECTION_RADIUS,
+    )
     app.comment_box.grid(
         row=5,
         column=0,
@@ -151,7 +244,13 @@ def build_bottom(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    bottom = ctk.CTkFrame(panel)
+    bottom = ctk.CTkFrame(
+        panel,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
     bottom.grid(row=3, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_MD))
     bottom.grid_columnconfigure(1, weight=1)
     app.bottom_frame = bottom
@@ -186,7 +285,12 @@ def build_bottom(app):
         sticky="w",
     )
 
-    app.status_label = ctk.CTkLabel(bottom, text="", font=style.FONT_BODY)
+    app.status_label = ctk.CTkLabel(
+        bottom,
+        text="",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    )
     app.status_label.grid(
         row=0,
         column=1,
@@ -218,8 +322,20 @@ def build_main(app):
 
     import customtkinter as ctk
 
-    panel = ctk.CTkFrame(app, corner_radius=16)
-    panel.grid(row=0, column=1, sticky="nsew", padx=(0, style.PAD_XL), pady=style.PAD_XL)
+    panel = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface_alt"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
+    panel.grid(
+        row=0,
+        column=1,
+        sticky="nsew",
+        padx=(0, style.PAD_XL),
+        pady=style.PAD_XL,
+    )
     panel.grid_columnconfigure(0, weight=1)
     panel.grid_rowconfigure(2, weight=1, minsize=300)
 
@@ -306,6 +422,7 @@ def build_ledger_widgets(app):
         anchor="e",
         justify="right",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     )
     app.ledger_sum.grid(
         row=3,

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -27,11 +27,21 @@ def _toggle_sample_btn(app, *_):
 def build_sidebar(app):
     import customtkinter as ctk
 
-    card = ctk.CTkFrame(app, corner_radius=16)
+    card = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
     card.grid(row=0, column=0, sticky="nsw", padx=style.PAD_XL, pady=style.PAD_XL)
 
-    ctk.CTkLabel(card, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE)\
-        .grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
+    ctk.CTkLabel(
+        card,
+        text="⚙️ Datautvalg",
+        font=style.FONT_TITLE_LARGE,
+        text_color=style.get_color("fg"),
+    ).grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
 
     app.file_path_var = ctk.StringVar(master=app, value="")
     create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
@@ -52,6 +62,7 @@ def build_sidebar(app):
         anchor="w",
         justify="left",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     ).grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
@@ -74,14 +85,20 @@ def build_sidebar(app):
         anchor="w",
         justify="left",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     ).grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
 
     app.add_drop_target(app.inv_drop, app.inv_drop.on_drop)
     app.add_drop_target(app.gl_drop, app.gl_drop.on_drop)
 
-    row_utv = ctk.CTkFrame(card)
+    row_utv = ctk.CTkFrame(card, fg_color="transparent")
     row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")
-    ctk.CTkLabel(row_utv, text="Antall tilfeldig utvalg", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        row_utv,
+        text="Antall tilfeldig utvalg",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=0, column=0, padx=(style.PAD_MD, 0), sticky="w"
     )
 
@@ -98,7 +115,12 @@ def build_sidebar(app):
         validatecommand=(vcmd_int, "%P"),
     ).grid(row=0, column=1, padx=(style.PAD_MD, 0))
 
-    ctk.CTkLabel(row_utv, text="År", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        row_utv,
+        text="År",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=1,
         column=0,
         padx=(style.PAD_MD, 0),
@@ -123,12 +145,27 @@ def build_sidebar(app):
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
     app._update_year_options()
 
-    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=style.FONT_TITLE)
+    app.lbl_filecount = ctk.CTkLabel(
+        card,
+        text="Antall bilag: –",
+        font=style.FONT_TITLE,
+        text_color=style.get_color("fg"),
+    )
     app.lbl_filecount.grid(row=9, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="w")
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.FONT_BODY_BOLD)\
-        .grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
-    opp = ctk.CTkFrame(card, corner_radius=8)
+    ctk.CTkLabel(
+        card,
+        text="Oppdragsinfo",
+        font=style.FONT_BODY_BOLD,
+        text_color=style.get_color("muted"),
+    ).grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
+    opp = ctk.CTkFrame(
+        card,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface_alt"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
     opp.grid(row=11, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
     opp.grid_columnconfigure(0, weight=0)
     opp.grid_columnconfigure(1, weight=1)
@@ -137,7 +174,12 @@ def build_sidebar(app):
     default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
     app.utfort_av_var = ctk.StringVar(master=app, value=default_user)
 
-    ctk.CTkLabel(opp, text="Kunde", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        opp,
+        text="Kunde",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=0,
         column=0,
         padx=(style.PAD_MD, style.PAD_MD),
@@ -151,7 +193,12 @@ def build_sidebar(app):
         state="disabled",
     )
     app.kunde_entry.grid(row=0, column=1, padx=(0, style.PAD_MD), pady=(style.PAD_MD, style.PAD_XS), sticky="ew")
-    ctk.CTkLabel(opp, text="Utført av", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        opp,
+        text="Utført av",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=1,
         column=0,
         padx=(style.PAD_MD, style.PAD_MD),
@@ -166,12 +213,19 @@ def build_sidebar(app):
         anchor="w",
         justify="left",
         wraplength=240,
+        text_color=style.get_color("muted"),
     )
     info_lbl.grid(row=2, column=0, columnspan=2, padx=(style.PAD_MD, style.PAD_MD), pady=(0, style.PAD_MD), sticky="w")
 
     card.grid_rowconfigure(20, weight=1)
 
-    status_card = ctk.CTkFrame(card, corner_radius=12)
+    status_card = ctk.CTkFrame(
+        card,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface_alt"),
+        border_color=style.get_color("border"),
+        border_width=style.OUTLINE_WIDTH,
+    )
     status_card.grid(
         row=100,
         column=0,
@@ -184,19 +238,54 @@ def build_sidebar(app):
     title_font = style.FONT_TITLE_LARGE
     body_font = style.FONT_BODY
 
-    ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
+    ctk.CTkLabel(
+        status_card,
+        text="Status",
+        font=title_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("fg"),
+    )\
         .grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
 
-    app.lbl_st_sum_kontrollert = ctk.CTkLabel(status_card, text="Sum kontrollert: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_kontrollert = ctk.CTkLabel(
+        status_card,
+        text="Sum kontrollert: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_sum_kontrollert.grid(row=1, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_sum_alle = ctk.CTkLabel(status_card, text="Sum alle bilag: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_alle = ctk.CTkLabel(
+        status_card,
+        text="Sum alle bilag: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_sum_alle.grid(row=2, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_pct = ctk.CTkLabel(status_card, text="% kontrollert av sum: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_pct = ctk.CTkLabel(
+        status_card,
+        text="% kontrollert av sum: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_pct.grid(row=3, column=0, sticky="ew", pady=(0, style.PAD_MD))
 
-    app.lbl_st_godkjent = ctk.CTkLabel(status_card, text="Godkjent: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_godkjent = ctk.CTkLabel(
+        status_card,
+        text="Godkjent: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_godkjent.grid(row=4, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
     app.lbl_st_ikkegodkjent = ctk.CTkLabel(status_card, text="Ikke godkjent: –", font=body_font, anchor="center", justify="center")

--- a/gui/style.py
+++ b/gui/style.py
@@ -12,31 +12,38 @@ class Style:
     """Samler felles stilkonfigurasjon for GUI."""
 
     # Knappestil
-    BTN_FG: str = "#1f6aa5"
-    BTN_HOVER: str = "#185a8b"
-    BTN_RADIUS: int = 8
+    BTN_FG: str = "#0b4b8f"
+    BTN_HOVER: str = "#093d73"
+    BTN_RADIUS: int = 10
 
     # Farger per tema
     COLORS: Dict[str, Dict[str, str]] = field(
         default_factory=lambda: {
-            "success": {"light": "#2ecc71", "dark": "#27ae60"},
-            "success_hover": {"light": "#29b765", "dark": "#219150"},
-            "error": {"light": "#e74c3c", "dark": "#c0392b"},
-            "error_hover": {"light": "#cf4334", "dark": "#992d22"},
+            "success": {"light": "#1f8b4c", "dark": "#2ecc71"},
+            "success_hover": {"light": "#1a7441", "dark": "#27ae60"},
+            "error": {"light": "#c94c4c", "dark": "#e06666"},
+            "error_hover": {"light": "#a93f3f", "dark": "#cc5252"},
             # Generelle farger
-            "bg": {"light": "#ffffff", "dark": "#1e1e1e"},
-            "fg": {"light": "#000000", "dark": "#e6e6e6"},
+            "bg": {"light": "#ffffff", "dark": "#0f141b"},
+            "background": {"light": "#f1f4f9", "dark": "#101620"},
+            "surface": {"light": "#ffffff", "dark": "#18212b"},
+            "surface_alt": {"light": "#f7f9fc", "dark": "#141b24"},
+            "border": {"light": "#d8e1ec", "dark": "#283240"},
+            "muted": {"light": "#5c6b80", "dark": "#9aa8bc"},
+            "fg": {"light": "#0f1b2b", "dark": "#e6edf7"},
+            "button_text": {"light": "#f5f7fb", "dark": "#f5f7fb"},
+            "accent": {"light": "#0d63c6", "dark": "#4ba3ff"},
             # Dra-og-slipp felt
-            "dnd_bg": {"light": "#f5f6f7", "dark": "#2b2b2b"},
-            "dnd_border": {"light": "#a8b1bb", "dark": "#4a4f55"},
+            "dnd_bg": {"light": "#f4f7fb", "dark": "#1a2330"},
+            "dnd_border": {"light": "#9fb2cc", "dark": "#37506f"},
             # Tabellfarger
-            "table_bg": {"light": "#ffffff", "dark": "#1e1e1e"},
-            "table_fg": {"light": "#000000", "dark": "#e6e6e6"},
-            "table_header_bg": {"light": "#f0f0f0", "dark": "#2a2a2a"},
-            "table_sel_bg": {"light": "#d0d0ff", "dark": "#3a3a3a"},
-            "table_sel_fg": {"light": "#000000", "dark": "#ffffff"},
-            "table_row_odd": {"light": "#f6f6f6", "dark": "#232323"},
-            "table_row_even": {"light": "#ffffff", "dark": "#1e1e1e"},
+            "table_bg": {"light": "#ffffff", "dark": "#18212b"},
+            "table_fg": {"light": "#0f1b2b", "dark": "#e6edf7"},
+            "table_header_bg": {"light": "#e6edf7", "dark": "#1f2a38"},
+            "table_sel_bg": {"light": "#d1e3ff", "dark": "#2b3b52"},
+            "table_sel_fg": {"light": "#0f1b2b", "dark": "#ffffff"},
+            "table_row_odd": {"light": "#f5f8fc", "dark": "#202c3a"},
+            "table_row_even": {"light": "#ffffff", "dark": "#1b2533"},
         }
     )
 
@@ -59,7 +66,7 @@ class Style:
             raise KeyError(f"Ukjent fargenavn: {name}") from e
 
     # Skrifttyper
-    FONT_FAMILY: str = "Helvetica"
+    FONT_FAMILY: str = "Segoe UI"
     # Skrifttyper (initialiseres lazily)
     FONT_TITLE: Optional[object] = None
     FONT_BODY: Optional[object] = None
@@ -71,12 +78,16 @@ class Style:
     FONT_SMALL_ITALIC: Optional[object] = None
 
     # Standard spacing
-    PAD_XL: int = 14
+    PAD_XL: int = 16
     PAD_LG: int = 12
     PAD_MD: int = 8
     PAD_SM: int = 6
     PAD_XS: int = 4
     PAD_XXS: int = 2
+
+    CARD_RADIUS: int = 16
+    SECTION_RADIUS: int = 14
+    OUTLINE_WIDTH: int = 1
 
 
 style = Style()


### PR DESCRIPTION
## Sammendrag
- introduser ny fargepalett, typografi og spacing-konstanter for et mer profesjonelt preg
- oppdater hovedpanel, handlingsknapper og detaljseksjoner med kortstil, rammer og dempet typografi
- gi sidepanelet og dra-og-slipp-soner en mer stilisert innpakning med konsekvent fargebruk

## Testing
- `pytest` *(feilet: mangler pandas/openpyxl i miljøet)*

------
https://chatgpt.com/codex/tasks/task_e_68ff21959ea08328a9c38094262e5771