### PR TITLE
Gi hovedgrensesnittet en mer profesjonell stil

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -59,8 +59,10 @@ def create_button(master, **kwargs):
     options = {
         "fg_color": style.BTN_FG,
         "hover_color": style.BTN_HOVER,
+        "text_color": style.BTN_TEXT,
         "font": style.FONT_BODY,
         "corner_radius": style.BTN_RADIUS,
+        "border_width": 0,
     }
     options.update(kwargs)
     return ctk.CTkButton(master, **options)

--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -15,10 +15,10 @@ class DropZone(ctk.CTkFrame):
         super().__init__(
             parent,
             height=70,
-            corner_radius=style.BTN_RADIUS,
+            corner_radius=style.CARD_RADIUS,
             fg_color=dnd_bg,
             border_color=dnd_border,
-            border_width=2,
+            border_width=style.CARD_BORDER_WIDTH + 1,
         )
 
         self._dnd_bg = dnd_bg

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -9,58 +9,120 @@ def build_header(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    head = ctk.CTkFrame(panel)
-    head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
-    head.grid_columnconfigure(6, weight=1)
+    head = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_bg"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
+    head.grid(
+        row=0,
+        column=0,
+        sticky="ew",
+        padx=style.PAD_LG,
+        pady=(style.PAD_LG, style.PAD_SM),
+    )
+    head.grid_columnconfigure(0, weight=1)
+    head.grid_columnconfigure(1, weight=0)
 
-    head_font = style.FONT_TITLE_LITE
+    content = ctk.CTkFrame(head, fg_color="transparent")
+    content.grid(row=0, column=0, columnspan=2, sticky="nsew")
+    content.grid_columnconfigure(0, weight=1)
+    content.grid_columnconfigure(1, weight=0)
 
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.FONT_TITLE)
-    status_frame = ctk.CTkFrame(head, fg_color="transparent")
-    status_frame.grid(row=0, column=1, padx=style.PAD_MD, sticky="w")
-    app.lbl_status_label = ctk.CTkLabel(status_frame, text="Status:", font=head_font)
-    app.lbl_status_label.grid(row=0, column=0, padx=(0, style.PAD_XXS))
+    info = ctk.CTkFrame(content, fg_color="transparent")
+    info.grid(row=0, column=0, sticky="nsew", padx=style.PAD_LG, pady=style.PAD_LG)
+    info.grid_columnconfigure(1, weight=1)
+
+    app.lbl_count = ctk.CTkLabel(
+        info,
+        text="Bilag: –/–",
+        font=style.FONT_TITLE_LARGE,
+        text_color=style.get_color("accent"),
+    )
+    app.lbl_count.grid(row=0, column=0, sticky="w")
+
+    status_chip = ctk.CTkFrame(
+        info,
+        fg_color=style.get_color_pair("pill_bg"),
+        border_color=style.get_color_pair("pill_border"),
+        border_width=style.CARD_BORDER_WIDTH,
+        corner_radius=999,
+    )
+    status_chip.grid(row=0, column=1, sticky="w", padx=(style.PAD_MD, 0))
+
+    app.lbl_status_label = ctk.CTkLabel(
+        status_chip,
+        text="Status",
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    )
+    app.lbl_status_label.pack(side="left", padx=(style.PAD_MD, style.PAD_XXS), pady=style.PAD_XS)
     app.lbl_status = ctk.CTkLabel(
-        status_frame,
+        status_chip,
         text="–",
-        font=head_font,
+        font=style.FONT_BODY_BOLD,
+        text_color=style.get_color("pill_text"),
+    )
+    app.lbl_status.pack(side="left", padx=(0, style.PAD_MD), pady=style.PAD_XS)
+
+    app.lbl_invoice = ctk.CTkLabel(
+        info,
+        text="Fakturanr: –",
+        font=style.FONT_TITLE_LITE,
         text_color=style.get_color("fg"),
     )
-    app.lbl_status.grid(row=0, column=1)
-    app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
-    app.lbl_count.grid(row=0, column=0, padx=(style.PAD_XS, style.PAD_LG))
-    app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
-    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
+    app.lbl_invoice.grid(row=1, column=0, columnspan=2, sticky="w", pady=(style.PAD_XXS, 0))
+
+    actions_row = ctk.CTkFrame(info, fg_color="transparent")
+    actions_row.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(style.PAD_SM, 0))
+    actions_row.grid_columnconfigure(1, weight=1)
+    actions_row.grid_columnconfigure(2, weight=0)
+
+    create_button(
+        actions_row,
+        text="📋 Kopier fakturanr",
+        command=app.copy_invoice,
+    ).grid(row=0, column=0, padx=(0, style.PAD_MD))
+
     app.copy_feedback = ctk.CTkLabel(
-        head,
+        actions_row,
         text="",
         text_color=style.get_color("success"),
-        font=style.FONT_BODY,
+        font=style.FONT_SMALL,
+        anchor="w",
     )
-    app.copy_feedback.grid(row=0, column=4, padx=style.PAD_MD, sticky="w")
+    app.copy_feedback.grid(row=0, column=1, sticky="w")
 
     app.inline_status = ctk.CTkLabel(
-        head,
+        actions_row,
         text="",
-        text_color=style.get_color("success"),
-        font=style.FONT_BODY,
+        text_color=style.get_color("accent"),
+        font=style.FONT_SMALL,
+        anchor="e",
     )
-    app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
+    app.inline_status.grid(row=0, column=2, sticky="e")
 
-    ctk.CTkLabel(head, text="Temavalg", font=style.FONT_BODY).grid(
-        row=0,
-        column=7,
-        padx=(style.PAD_MD, style.PAD_XS),
-    )
+    controls = ctk.CTkFrame(content, fg_color="transparent")
+    controls.grid(row=0, column=1, sticky="ne", padx=(0, style.PAD_LG), pady=style.PAD_LG)
+
+    ctk.CTkLabel(
+        controls,
+        text="Temavalg",
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=0, column=0, sticky="e", pady=(0, style.PAD_XXS))
     default_theme_label = DEFAULT_APPEARANCE_MODE.title()
     app.theme_var = ctk.StringVar(value=default_theme_label)
     app.theme_menu = ctk.CTkOptionMenu(
-        head,
+        controls,
         variable=app.theme_var,
         values=["Light", "Dark"],
         command=app._switch_theme,
+        anchor="center",
     )
-    app.theme_menu.grid(row=0, column=8, padx=(0, style.PAD_MD))
+    app.theme_menu.grid(row=1, column=0, sticky="e")
     app.theme_menu.set(default_theme_label)
 
     return head
@@ -72,29 +134,62 @@ def build_action_buttons(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    btns = ctk.CTkFrame(panel)
-    btns.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
-    btns.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
+    btns = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_bg"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
+    btns.grid(
+        row=1,
+        column=0,
+        sticky="ew",
+        padx=style.PAD_LG,
+        pady=(0, style.PAD_SM),
+    )
+    btns.grid_columnconfigure(0, weight=1)
+
+    header = ctk.CTkLabel(
+        btns,
+        text="Behandling av bilag",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("muted"),
+        anchor="w",
+    )
+    header.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=(style.PAD_LG, style.PAD_XS))
+
+    row = ctk.CTkFrame(btns, fg_color="transparent")
+    row.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_LG))
+    row.grid_columnconfigure((0, 1, 2, 3, 4), weight=1, uniform="actions")
 
     create_button(
-        btns,
+        row,
         text="✅ Godkjent",
-        fg_color=style.get_color("success"),
-        hover_color=style.get_color("success_hover"),
+        fg_color=style.get_color_pair("success"),
+        hover_color=style.get_color_pair("success_hover"),
         command=lambda: app.set_decision_and_next("Godkjent"),
-    ).grid(row=0, column=0, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    ).grid(row=0, column=0, padx=style.PAD_SM, sticky="ew")
+
     create_button(
-        btns,
+        row,
         text="⛔ Ikke godkjent",
-        fg_color=style.get_color("error"),
-        hover_color=style.get_color("error_hover"),
+        fg_color=style.get_color_pair("error"),
+        hover_color=style.get_color_pair("error_hover"),
         command=lambda: app.set_decision_and_next("Ikke godkjent"),
-    ).grid(row=0, column=1, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    create_button(btns, text="🔗 Åpne PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    app.btn_prev = create_button(btns, text="⬅ Forrige", command=app.prev)
-    app.btn_prev.grid(row=0, column=3, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    app.btn_next = create_button(btns, text="➡ Neste", command=app.next)
-    app.btn_next.grid(row=0, column=4, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    ).grid(row=0, column=1, padx=style.PAD_SM, sticky="ew")
+
+    create_button(
+        row,
+        text="🔗 Åpne PowerOffice",
+        command=app.open_in_po,
+    ).grid(row=0, column=2, padx=style.PAD_SM, sticky="ew")
+
+    app.btn_prev = create_button(row, text="⬅ Forrige", command=app.prev)
+    app.btn_prev.grid(row=0, column=3, padx=style.PAD_SM, sticky="ew")
+
+    app.btn_next = create_button(row, text="➡ Neste", command=app.next)
+    app.btn_next.grid(row=0, column=4, padx=style.PAD_SM, sticky="ew")
 
     return btns
 
@@ -105,41 +200,137 @@ def build_panes(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    paned = ctk.CTkFrame(panel)
-    paned.grid(row=2, column=0, sticky="nsew", padx=style.PAD_LG, pady=(style.PAD_XS, style.PAD_SM))
+    paned = ctk.CTkFrame(panel, fg_color="transparent")
+    paned.grid(
+        row=2,
+        column=0,
+        sticky="nsew",
+        padx=style.PAD_LG,
+        pady=(style.PAD_SM, style.PAD_SM),
+    )
     paned.grid_columnconfigure((0, 1), weight=1, minsize=400)
     paned.grid_rowconfigure(0, weight=1)
 
-    left = ctk.CTkFrame(paned)
-    right = ctk.CTkFrame(paned)
+    left = ctk.CTkFrame(paned, fg_color="transparent")
+    right = ctk.CTkFrame(paned, fg_color="transparent")
     left.grid(row=0, column=0, sticky="nsew")
     right.grid(row=0, column=1, sticky="nsew")
     app.right_frame = right
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    ctk.CTkLabel(
+        left,
+        text="Detaljer for bilag",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(0, style.PAD_XS))
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
-    app.detail_box = ctk.CTkTextbox(left, height=360, font=style.FONT_BODY)
-    app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(style.PAD_MD, style.PAD_SM), pady=(0, style.PAD_MD))
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
-    right.grid_columnconfigure(0, weight=1)
-    right.grid_columnconfigure(1, weight=0)
-    right.grid_rowconfigure(1, weight=3, minsize=150)
-    right.grid_rowconfigure(5, weight=1, minsize=120)
-
-    ctk.CTkLabel(right, text="Kommentar", font=style.FONT_TITLE_SMALL)\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(style.PAD_MD, style.PAD_SM), pady=(style.PAD_MD, style.PAD_XS))
-    app.comment_box = ctk.CTkTextbox(right, font=style.FONT_SMALL)
-    app.comment_box.grid(
-        row=5,
+    detail_card = ctk.CTkFrame(
+        left,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_inner"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
+    detail_card.grid(
+        row=1,
         column=0,
-        columnspan=2,
         sticky="nsew",
         padx=(style.PAD_MD, style.PAD_SM),
         pady=(0, style.PAD_MD),
+    )
+    detail_card.grid_rowconfigure(0, weight=1)
+    detail_card.grid_columnconfigure(0, weight=1)
+
+    app.detail_box = ctk.CTkTextbox(
+        detail_card,
+        height=360,
+        font=style.FONT_BODY,
+        fg_color=style.get_color_pair("card_inner"),
+        border_width=0,
+    )
+    app.detail_box.grid(
+        row=0,
+        column=0,
+        sticky="nsew",
+        padx=style.PAD_MD,
+        pady=style.PAD_MD,
+    )
+
+    ctk.CTkLabel(
+        right,
+        text="Hovedbok (bilagslinjer)",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(0, style.PAD_XS))
+    right.grid_columnconfigure(0, weight=1)
+    right.grid_rowconfigure(1, weight=3, minsize=150)
+    right.grid_rowconfigure(3, weight=1, minsize=120)
+
+    ledger_card = ctk.CTkFrame(
+        right,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_inner"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
+    ledger_card.grid(
+        row=1,
+        column=0,
+        sticky="nsew",
+        padx=(style.PAD_MD, style.PAD_SM),
+        pady=(0, style.PAD_MD),
+    )
+    ledger_card.grid_columnconfigure(0, weight=1)
+    ledger_card.grid_columnconfigure(1, weight=0)
+    ledger_card.grid_rowconfigure(0, weight=1)
+    ledger_card.grid_rowconfigure(1, weight=0)
+    ledger_card.grid_rowconfigure(2, weight=0)
+    app.ledger_container = ledger_card
+
+    ctk.CTkLabel(
+        right,
+        text="Kommentar",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("muted"),
+    ).grid(
+        row=2,
+        column=0,
+        sticky="w",
+        padx=(style.PAD_MD, style.PAD_SM),
+        pady=(0, style.PAD_XS),
+    )
+
+    comment_card = ctk.CTkFrame(
+        right,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_inner"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
+    comment_card.grid(
+        row=3,
+        column=0,
+        sticky="nsew",
+        padx=(style.PAD_MD, style.PAD_SM),
+        pady=(0, style.PAD_SM),
+    )
+    comment_card.grid_rowconfigure(0, weight=1)
+    comment_card.grid_columnconfigure(0, weight=1)
+
+    app.comment_box = ctk.CTkTextbox(
+        comment_card,
+        font=style.FONT_SMALL,
+        fg_color=style.get_color_pair("card_inner"),
+        border_width=0,
+    )
+    app.comment_box.grid(
+        row=0,
+        column=0,
+        sticky="nsew",
+        padx=style.PAD_MD,
+        pady=style.PAD_MD,
     )
 
     return paned
@@ -151,9 +342,23 @@ def build_bottom(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    bottom = ctk.CTkFrame(panel)
-    bottom.grid(row=3, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_MD))
+    bottom = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_bg"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
+    bottom.grid(
+        row=3,
+        column=0,
+        sticky="ew",
+        padx=style.PAD_LG,
+        pady=(0, style.PAD_LG),
+    )
+    bottom.grid_columnconfigure(0, weight=0)
     bottom.grid_columnconfigure(1, weight=1)
+    bottom.grid_columnconfigure(2, weight=0)
     app.bottom_frame = bottom
 
     def _export_pdf():
@@ -175,29 +380,29 @@ def build_bottom(app):
 
         run_in_thread(worker)
 
-    export_btn = create_button(
-        bottom, text="📄 Eksporter PDF rapport", command=_export_pdf
-    )
-    export_btn.grid(
-        row=0,
-        column=0,
-        padx=(style.PAD_MD, style.PAD_SM),
-        pady=style.PAD_SM,
-        sticky="w",
-    )
+    content = ctk.CTkFrame(bottom, fg_color="transparent")
+    content.grid(row=0, column=0, columnspan=3, sticky="ew", padx=style.PAD_LG, pady=style.PAD_LG)
+    content.grid_columnconfigure(1, weight=1)
 
-    app.status_label = ctk.CTkLabel(bottom, text="", font=style.FONT_BODY)
-    app.status_label.grid(
-        row=0,
-        column=1,
-        padx=style.PAD_SM,
-        pady=style.PAD_SM,
-        sticky="ew",
+    export_btn = create_button(
+        content,
+        text="📄 Eksporter PDF rapport",
+        command=_export_pdf,
     )
+    export_btn.grid(row=0, column=0, padx=(0, style.PAD_MD))
+
+    app.status_label = ctk.CTkLabel(
+        content,
+        text="",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+        anchor="w",
+    )
+    app.status_label.grid(row=0, column=1, sticky="ew")
 
     app.progress_bar = ctk.CTkProgressBar(
-        bottom,
-        width=120,
+        content,
+        width=180,
         progress_color=style.get_color("success"),
         fg_color=style.get_color("bg"),
     )
@@ -205,8 +410,8 @@ def build_bottom(app):
     app.progress_bar_grid = {
         "row": 0,
         "column": 2,
-        "padx": style.PAD_SM,
-        "pady": style.PAD_SM,
+        "padx": (style.PAD_MD, 0),
+        "pady": (0, 0),
         "sticky": "e",
     }
 
@@ -218,8 +423,20 @@ def build_main(app):
 
     import customtkinter as ctk
 
-    panel = ctk.CTkFrame(app, corner_radius=16)
-    panel.grid(row=0, column=1, sticky="nsew", padx=(0, style.PAD_XL), pady=style.PAD_XL)
+    panel = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_bg"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
+    panel.grid(
+        row=0,
+        column=1,
+        sticky="nsew",
+        padx=(0, style.PAD_XL),
+        pady=style.PAD_XL,
+    )
     panel.grid_columnconfigure(0, weight=1)
     panel.grid_rowconfigure(2, weight=1, minsize=300)
 
@@ -261,10 +478,19 @@ def build_ledger_widgets(app):
         sort_treeview,
     )
 
-    right = app.right_frame
+    container = getattr(app, "ledger_container", app.right_frame)
+    container.grid_columnconfigure(0, weight=1)
+    container.grid_columnconfigure(1, weight=0)
+    container.grid_rowconfigure(0, weight=1)
+    container.grid_rowconfigure(1, weight=0)
+    container.grid_rowconfigure(2, weight=0)
     app.ledger_cols = LEDGER_COLS
     app.ledger_tree = ttk.Treeview(
-        right, columns=LEDGER_COLS, show="headings", height=10, style="Custom.Treeview"
+        container,
+        columns=LEDGER_COLS,
+        show="headings",
+        height=10,
+        style="Custom.Treeview",
     )
     for col, w, anchor in [
         ("Kontonr", 90, "w"),
@@ -282,12 +508,12 @@ def build_ledger_widgets(app):
         )
         app.ledger_tree.column(col, width=w, minwidth=60, anchor=anchor, stretch=True)
 
-    yscroll = ctk.CTkScrollbar(right, orientation="vertical", command=app.ledger_tree.yview)
-    xscroll = ctk.CTkScrollbar(right, orientation="horizontal", command=app.ledger_tree.xview)
+    yscroll = ctk.CTkScrollbar(container, orientation="vertical", command=app.ledger_tree.yview)
+    xscroll = ctk.CTkScrollbar(container, orientation="horizontal", command=app.ledger_tree.xview)
     app.ledger_tree.configure(yscrollcommand=yscroll.set, xscrollcommand=xscroll.set)
-    app.ledger_tree.grid(row=1, column=0, sticky="nsew")
-    yscroll.grid(row=1, column=1, sticky="ns")
-    xscroll.grid(row=2, column=0, sticky="ew")
+    app.ledger_tree.grid(row=0, column=0, sticky="nsew", padx=(style.PAD_MD, 0), pady=(style.PAD_MD, 0))
+    yscroll.grid(row=0, column=1, sticky="ns", pady=(style.PAD_MD, style.PAD_MD))
+    xscroll.grid(row=1, column=0, sticky="ew", padx=(style.PAD_MD, 0))
 
     app._prev_ledger_width = None
     app._ledger_configure_id = app.ledger_tree.bind(
@@ -301,17 +527,18 @@ def build_ledger_widgets(app):
         sort_treeview(app.ledger_tree, app.ledger_cols[0], False, app)
 
     app.ledger_sum = ctk.CTkLabel(
-        right,
+        container,
         text=" ",
         anchor="e",
         justify="right",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     )
     app.ledger_sum.grid(
-        row=3,
+        row=2,
         column=0,
         columnspan=2,
         sticky="ew",
-        padx=(0, style.PAD_LG),
+        padx=(style.PAD_MD, style.PAD_MD),
         pady=(style.PAD_SM, PADDING_Y),
     )

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -27,15 +27,28 @@ def _toggle_sample_btn(app, *_):
 def build_sidebar(app):
     import customtkinter as ctk
 
-    card = ctk.CTkFrame(app, corner_radius=16)
+    card = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("sidebar_bg"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("sidebar_border"),
+    )
     card.grid(row=0, column=0, sticky="nsw", padx=style.PAD_XL, pady=style.PAD_XL)
 
-    ctk.CTkLabel(card, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE)\
-        .grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
+    ctk.CTkLabel(
+        card,
+        text="⚙️ Datautvalg",
+        font=style.FONT_TITLE_LARGE,
+        text_color=style.get_color("accent"),
+    ).grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
 
     app.file_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
-        .grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
+    create_button(
+        card,
+        text="Velg leverandørfakturaer (Excel)…",
+        command=app.choose_file,
+    ).grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
     def _drop_invoice(event):
         path = parse_dropped_path(event)
         if not path:
@@ -52,11 +65,15 @@ def build_sidebar(app):
         anchor="w",
         justify="left",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     ).grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
-        .grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
+    create_button(
+        card,
+        text="Velg hovedbok (Excel)…",
+        command=app.choose_gl_file,
+    ).grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
 
     def _drop_gl(event):
         path = parse_dropped_path(event)
@@ -74,16 +91,24 @@ def build_sidebar(app):
         anchor="w",
         justify="left",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     ).grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
 
     app.add_drop_target(app.inv_drop, app.inv_drop.on_drop)
     app.add_drop_target(app.gl_drop, app.gl_drop.on_drop)
 
-    row_utv = ctk.CTkFrame(card)
-    row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")
-    ctk.CTkLabel(row_utv, text="Antall tilfeldig utvalg", font=style.FONT_BODY).grid(
-        row=0, column=0, padx=(style.PAD_MD, 0), sticky="w"
+    row_utv = ctk.CTkFrame(
+        card,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_bg"),
     )
+    row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")
+    ctk.CTkLabel(
+        row_utv,
+        text="Antall tilfeldig utvalg",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(row=0, column=0, padx=(style.PAD_MD, 0), sticky="w")
 
     def _validate_int(P: str) -> bool:
         return P.isdigit() or P == ""
@@ -98,7 +123,12 @@ def build_sidebar(app):
         validatecommand=(vcmd_int, "%P"),
     ).grid(row=0, column=1, padx=(style.PAD_MD, 0))
 
-    ctk.CTkLabel(row_utv, text="År", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        row_utv,
+        text="År",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=1,
         column=0,
         padx=(style.PAD_MD, 0),
@@ -117,18 +147,38 @@ def build_sidebar(app):
     )
     app.year_combo.grid(row=1, column=1, padx=(style.PAD_MD, 0), pady=(style.PAD_SM, 0))
 
-    app.sample_btn = create_button(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
+    app.sample_btn = create_button(
+        card,
+        text="🎲 Lag utvalg",
+        command=app.make_sample,
+        state="disabled",
+    )
     app.sample_btn.grid(row=8, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_SM), sticky="ew")
 
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
     app._update_year_options()
 
-    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=style.FONT_TITLE)
+    app.lbl_filecount = ctk.CTkLabel(
+        card,
+        text="Antall bilag: –",
+        font=style.FONT_TITLE,
+        text_color=style.get_color("accent"),
+    )
     app.lbl_filecount.grid(row=9, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="w")
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.FONT_BODY_BOLD)\
-        .grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
-    opp = ctk.CTkFrame(card, corner_radius=8)
+    ctk.CTkLabel(
+        card,
+        text="Oppdragsinfo",
+        font=style.FONT_BODY_BOLD,
+        text_color=style.get_color("muted"),
+    ).grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
+    opp = ctk.CTkFrame(
+        card,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_bg"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
     opp.grid(row=11, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
     opp.grid_columnconfigure(0, weight=0)
     opp.grid_columnconfigure(1, weight=1)
@@ -137,7 +187,12 @@ def build_sidebar(app):
     default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
     app.utfort_av_var = ctk.StringVar(master=app, value=default_user)
 
-    ctk.CTkLabel(opp, text="Kunde", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        opp,
+        text="Kunde",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=0,
         column=0,
         padx=(style.PAD_MD, style.PAD_MD),
@@ -151,7 +206,12 @@ def build_sidebar(app):
         state="disabled",
     )
     app.kunde_entry.grid(row=0, column=1, padx=(0, style.PAD_MD), pady=(style.PAD_MD, style.PAD_XS), sticky="ew")
-    ctk.CTkLabel(opp, text="Utført av", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(
+        opp,
+        text="Utført av",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    ).grid(
         row=1,
         column=0,
         padx=(style.PAD_MD, style.PAD_MD),
@@ -166,12 +226,19 @@ def build_sidebar(app):
         anchor="w",
         justify="left",
         wraplength=240,
+        text_color=style.get_color("muted"),
     )
     info_lbl.grid(row=2, column=0, columnspan=2, padx=(style.PAD_MD, style.PAD_MD), pady=(0, style.PAD_MD), sticky="w")
 
     card.grid_rowconfigure(20, weight=1)
 
-    status_card = ctk.CTkFrame(card, corner_radius=12)
+    status_card = ctk.CTkFrame(
+        card,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color_pair("card_bg"),
+        border_width=style.CARD_BORDER_WIDTH,
+        border_color=style.get_color_pair("card_border"),
+    )
     status_card.grid(
         row=100,
         column=0,
@@ -184,25 +251,73 @@ def build_sidebar(app):
     title_font = style.FONT_TITLE_LARGE
     body_font = style.FONT_BODY
 
-    ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
-        .grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
+    ctk.CTkLabel(
+        status_card,
+        text="Status",
+        font=title_font,
+        text_color=style.get_color("accent"),
+        anchor="center",
+        justify="center",
+    ).grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
 
-    app.lbl_st_sum_kontrollert = ctk.CTkLabel(status_card, text="Sum kontrollert: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_kontrollert = ctk.CTkLabel(
+        status_card,
+        text="Sum kontrollert: –",
+        font=body_font,
+        text_color=style.get_color("muted"),
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_sum_kontrollert.grid(row=1, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_sum_alle = ctk.CTkLabel(status_card, text="Sum alle bilag: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_alle = ctk.CTkLabel(
+        status_card,
+        text="Sum alle bilag: –",
+        font=body_font,
+        text_color=style.get_color("muted"),
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_sum_alle.grid(row=2, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_pct = ctk.CTkLabel(status_card, text="% kontrollert av sum: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_pct = ctk.CTkLabel(
+        status_card,
+        text="% kontrollert av sum: –",
+        font=body_font,
+        text_color=style.get_color("muted"),
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_pct.grid(row=3, column=0, sticky="ew", pady=(0, style.PAD_MD))
 
-    app.lbl_st_godkjent = ctk.CTkLabel(status_card, text="Godkjent: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_godkjent = ctk.CTkLabel(
+        status_card,
+        text="Godkjent: –",
+        font=body_font,
+        text_color=style.get_color("muted"),
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_godkjent.grid(row=4, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_ikkegodkjent = ctk.CTkLabel(status_card, text="Ikke godkjent: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_ikkegodkjent = ctk.CTkLabel(
+        status_card,
+        text="Ikke godkjent: –",
+        font=body_font,
+        text_color=style.get_color("muted"),
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_ikkegodkjent.grid(row=5, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_gjen = ctk.CTkLabel(status_card, text="Gjenstår å kontrollere: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_gjen = ctk.CTkLabel(
+        status_card,
+        text="Gjenstår å kontrollere: –",
+        font=body_font,
+        text_color=style.get_color("muted"),
+        anchor="center",
+        justify="center",
+    )
     app.lbl_st_gjen.grid(row=6, column=0, sticky="ew", pady=(style.PAD_SM, PADDING_Y))
 
     try:

--- a/gui/style.py
+++ b/gui/style.py
@@ -12,9 +12,18 @@ class Style:
     """Samler felles stilkonfigurasjon for GUI."""
 
     # Knappestil
-    BTN_FG: str = "#1f6aa5"
-    BTN_HOVER: str = "#185a8b"
-    BTN_RADIUS: int = 8
+    BTN_FG: Tuple[str, str] = field(
+        default_factory=lambda: ("#134168", "#4b97ff")
+    )
+    BTN_HOVER: Tuple[str, str] = field(
+        default_factory=lambda: ("#0f3656", "#357edc")
+    )
+    BTN_TEXT: Tuple[str, str] = field(
+        default_factory=lambda: ("#ffffff", "#0b1624")
+    )
+    BTN_RADIUS: int = 12
+    CARD_RADIUS: int = 18
+    CARD_BORDER_WIDTH: int = 1
 
     # Farger per tema
     COLORS: Dict[str, Dict[str, str]] = field(
@@ -26,6 +35,19 @@ class Style:
             # Generelle farger
             "bg": {"light": "#ffffff", "dark": "#1e1e1e"},
             "fg": {"light": "#000000", "dark": "#e6e6e6"},
+            "muted": {"light": "#5b6b7f", "dark": "#c2cad8"},
+            "accent": {"light": "#0f4c81", "dark": "#63a9ff"},
+            "accent_soft": {"light": "#dae6f5", "dark": "#233142"},
+            "accent_border": {"light": "#adc4e1", "dark": "#32425a"},
+            "card_bg": {"light": "#f5f7fb", "dark": "#1f2430"},
+            "card_inner": {"light": "#ffffff", "dark": "#232a37"},
+            "card_border": {"light": "#d7deeb", "dark": "#313a4d"},
+            "pill_bg": {"light": "#e5eef9", "dark": "#283549"},
+            "pill_border": {"light": "#bfd1ea", "dark": "#36445b"},
+            "pill_text": {"light": "#0f4c81", "dark": "#95c5ff"},
+            "btn_text": {"light": "#ffffff", "dark": "#0b1624"},
+            "sidebar_bg": {"light": "#ffffff", "dark": "#212733"},
+            "sidebar_border": {"light": "#dce2ed", "dark": "#323a4b"},
             # Dra-og-slipp felt
             "dnd_bg": {"light": "#f5f6f7", "dark": "#2b2b2b"},
             "dnd_border": {"light": "#a8b1bb", "dark": "#4a4f55"},


### PR DESCRIPTION
## Oppsummering
- Oppdaterte fargepalett, knappestandarder og kortgeometri i `style.py` for et mer helhetlig uttrykk.
- Reviderte hovedpanelet i `mainview.py` med kort, statuschip og tydeligere inndeling av handlinger, detaljer og hovedbok.
- Moderniserte sidepanelet og dra-og-slipp-sonene med harmonisert typografi og bakgrunnsfarger.

## Tester
- `pytest` *(feilet: mangler avhengighetene `pandas` og `openpyxl` i miljøet)*


------
https://chatgpt.com/codex/tasks/task_e_68ff21959ea08328a9c38094262e5771