### PR TITLE
Forbedre GUI-stilen med firmapreget design

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -61,6 +61,9 @@ def create_button(master, **kwargs):
         "hover_color": style.BTN_HOVER,
         "font": style.FONT_BODY,
         "corner_radius": style.BTN_RADIUS,
+        "text_color": style.get_color("button_text"),
+        "border_width": 1,
+        "border_color": style.get_color("border"),
     }
     options.update(kwargs)
     return ctk.CTkButton(master, **options)
@@ -161,12 +164,16 @@ class App:
             s.FONT_TITLE_LARGE = ctk.CTkFont(size=18, weight="bold", **kwargs)
         if s.FONT_TITLE_SMALL is None:
             s.FONT_TITLE_SMALL = ctk.CTkFont(size=15, weight="bold", **kwargs)
+        if s.FONT_TITLE_HERO is None:
+            s.FONT_TITLE_HERO = ctk.CTkFont(size=22, weight="bold", **kwargs)
         if s.FONT_BODY_BOLD is None:
             s.FONT_BODY_BOLD = ctk.CTkFont(size=14, weight="bold", **kwargs)
         if s.FONT_SMALL is None:
             s.FONT_SMALL = ctk.CTkFont(size=13, **kwargs)
         if s.FONT_SMALL_ITALIC is None:
             s.FONT_SMALL_ITALIC = ctk.CTkFont(size=12, slant="italic", **kwargs)
+        if s.FONT_CAPTION is None:
+            s.FONT_CAPTION = ctk.CTkFont(size=12, **kwargs)
 
     def _ensure_helpers(self):
         """Importer tunge hjelpefunksjoner fra ``helpers`` ved første behov."""
@@ -227,6 +234,7 @@ class App:
         self.sidebar = build_sidebar(self)
         self.sample_size_var.set("")
         self.year_var.set("")
+        self.refresh_theme_colors()
 
     def _build_main(self):
         from .mainview import build_main
@@ -235,6 +243,7 @@ class App:
         if self.gl_df is not None:
             self.after(0, self._build_ledger_widgets)
         self.render()
+        self.refresh_theme_colors()
 
     def _build_ledger_widgets(self):
         from .mainview import build_ledger_widgets
@@ -299,6 +308,86 @@ class App:
             ctk.set_window_scaling(scale)
         self._theme_initialized = True
 
+    def refresh_theme_colors(self):
+        def _configure(widget, **kwargs):
+            if not widget:
+                return
+            try:
+                widget.configure(**kwargs)
+            except TclError as exc:
+                logger.debug(f"Kunne ikke oppdatere widget: {exc}")
+
+        def _set_text(widget, color):
+            _configure(widget, text_color=color)
+
+        _configure(self, fg_color=style.get_color("app_bg"))
+        _configure(
+            getattr(self, "main_panel", None),
+            fg_color=style.get_color("surface"),
+            border_color=style.get_color("border"),
+        )
+        _configure(
+            getattr(self, "sidebar", None),
+            fg_color=style.get_color("sidebar_bg"),
+            border_color=style.get_color("border"),
+        )
+
+        for attr in ("sidebar_card", "sources_card", "sample_card", "assignment_card", "status_card"):
+            _configure(getattr(self, attr, None), fg_color=style.get_color("surface"), border_color=style.get_color("border"))
+
+        for widget, color_name in getattr(self, "sidebar_labels", []):
+            _set_text(widget, style.get_color(color_name))
+
+        for attr in ("inv_drop", "gl_drop"):
+            drop = getattr(self, attr, None)
+            if hasattr(drop, "refresh_theme"):
+                drop.refresh_theme()
+
+        _configure(getattr(self, "header_frame", None), fg_color=style.get_color("surface"), border_color=style.get_color("border"))
+        _configure(getattr(self, "header_accent", None), fg_color=style.get_color("accent"))
+        _set_text(getattr(self, "header_title", None), style.get_color("heading"))
+        _set_text(getattr(self, "header_tagline", None), style.get_color("muted"))
+        _set_text(getattr(self, "lbl_count", None), style.get_color("heading"))
+        _set_text(getattr(self, "lbl_status_label", None), style.get_color("muted"))
+        _set_text(getattr(self, "lbl_status", None), style.get_color("heading"))
+        _set_text(getattr(self, "lbl_invoice", None), style.get_color("muted"))
+        _set_text(getattr(self, "copy_feedback", None), style.get_color("accent"))
+        _set_text(getattr(self, "inline_status", None), style.get_color("success"))
+        _set_text(getattr(self, "theme_label", None), style.get_color("muted"))
+        _set_text(getattr(self, "lbl_filecount", None), style.get_color("heading"))
+
+        _configure(getattr(self, "action_frame", None), fg_color=style.get_color("surface"), border_color=style.get_color("border"))
+        _configure(getattr(self, "detail_frame", None), fg_color=style.get_color("surface"), border_color=style.get_color("border"))
+        _configure(getattr(self, "right_frame", None), fg_color=style.get_color("surface"), border_color=style.get_color("border"))
+        _set_text(getattr(self, "comment_box", None), style.get_color("fg"))
+
+        if getattr(self, "detail_box", None):
+            _configure(self.detail_box, fg_color=style.get_color("surface_alt"), text_color=style.get_color("fg"))
+        if getattr(self, "comment_box", None):
+            _configure(self.comment_box, fg_color=style.get_color("surface_alt"), text_color=style.get_color("fg"))
+
+        for name in (
+            "lbl_st_sum_kontrollert",
+            "lbl_st_sum_alle",
+            "lbl_st_pct",
+            "lbl_st_godkjent",
+            "lbl_st_ikkegodkjent",
+            "lbl_st_gjen",
+        ):
+            _set_text(getattr(self, name, None), style.get_color("muted"))
+
+        _configure(getattr(self, "bottom_frame", None), fg_color=style.get_color("surface"), border_color=style.get_color("border"))
+        _set_text(getattr(self, "status_label", None), style.get_color("muted"))
+        if getattr(self, "progress_bar", None):
+            _configure(
+                self.progress_bar,
+                fg_color=style.get_color("surface_alt"),
+                progress_color=style.get_color("success"),
+            )
+            self.progress_bar.grid(**getattr(self, "progress_bar_grid", {}))
+
+        _set_text(getattr(self, "ledger_sum", None), style.get_color("muted"))
+
     def _switch_theme(self, mode):
         ctk = _ctk()
         self._init_theme()
@@ -314,6 +403,7 @@ class App:
 
         apply_treeview_theme(self)
         update_treeview_stripes(self)
+        self.refresh_theme_colors()
         self.render()
 
     def _update_icon(self):
@@ -353,6 +443,11 @@ class App:
                 self.logo_img = ctk.CTkImage(light_image=img, size=(32, 32))
             except TypeError:
                 self.logo_img = ctk.CTkImage(img, size=(32, 32))
+            if getattr(self, "header_logo", None):
+                try:
+                    self.header_logo.configure(image=self.logo_img)
+                except TclError as exc:
+                    logger.debug(f"Kunne ikke oppdatere topp-logo: {exc}")
         except (ImportError, OSError) as e:
             logger.error(f"Kunne ikke laste logo: {e}")
             self.logo_img = None

--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -8,30 +8,19 @@ class DropZone(ctk.CTkFrame):
     """En ramme for dra-og-slipp med fargeendring ved drag hendelser."""
 
     def __init__(self, parent, text: str, drop_callback):
-        dnd_bg = style.get_color_pair("dnd_bg")
-        dnd_border = style.get_color_pair("dnd_border")
-        highlight = style.get_color_pair("success")
-
         super().__init__(
             parent,
-            height=70,
-            corner_radius=style.BTN_RADIUS,
-            fg_color=dnd_bg,
-            border_color=dnd_border,
+            height=80,
+            corner_radius=style.CARD_RADIUS,
             border_width=2,
         )
 
-        self._dnd_bg = dnd_bg
-        self._dnd_border = dnd_border
-        self._highlight = highlight
         self.drop_callback = drop_callback
-        self._label_text_color = dnd_border
-
         self.label = ctk.CTkLabel(
             self,
             text=text,
             anchor="center",
-            text_color=self._label_text_color,
+            wraplength=320,
         )
         self.label.pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
 
@@ -40,9 +29,19 @@ class DropZone(ctk.CTkFrame):
         for evt in ("<<DragLeave>>", "<<DropLeave>>"):
             self.dnd_bind(evt, self.reset_colors)
 
+        self.refresh_theme()
+
+    def refresh_theme(self):
+        self._dnd_bg = style.get_color_pair("accent_subtle")
+        self._dnd_border = style.get_color_pair("dnd_border")
+        self._highlight = style.get_color_pair("accent")
+        self._label_text_color = style.get_color_pair("muted_alt")
+        self.configure(fg_color=self._dnd_bg, border_color=self._dnd_border)
+        self.label.configure(text_color=self._label_text_color, font=style.FONT_BODY_BOLD)
+
     def _on_drag_enter(self, _):
         self.configure(fg_color=self._highlight, border_color=self._highlight)
-        self.label.configure(text_color=style.get_color_pair("fg"))
+        self.label.configure(text_color=style.get_color_pair("button_text"))
 
     def reset_colors(self, _=None):
         self.configure(fg_color=self._dnd_bg, border_color=self._dnd_border)

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -9,53 +9,141 @@ def build_header(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    head = ctk.CTkFrame(panel)
+    head = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
     head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
-    head.grid_columnconfigure(6, weight=1)
+    head.grid_columnconfigure(0, weight=1)
+    app.header_frame = head
 
-    head_font = style.FONT_TITLE_LITE
+    brand = ctk.CTkFrame(head, fg_color="transparent")
+    brand.grid(
+        row=0,
+        column=0,
+        columnspan=9,
+        sticky="ew",
+        padx=style.PAD_XL,
+        pady=(style.PAD_LG, style.PAD_SM),
+    )
+    brand.grid_columnconfigure(1, weight=1)
 
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.FONT_TITLE)
-    status_frame = ctk.CTkFrame(head, fg_color="transparent")
-    status_frame.grid(row=0, column=1, padx=style.PAD_MD, sticky="w")
-    app.lbl_status_label = ctk.CTkLabel(status_frame, text="Status:", font=head_font)
+    app.header_logo = ctk.CTkLabel(
+        brand,
+        text="",
+        image=getattr(app, "logo_img", None),
+        width=36,
+    )
+    app.header_logo.grid(row=0, column=0, rowspan=2, padx=(0, style.PAD_MD))
+
+    app.header_title = ctk.CTkLabel(
+        brand,
+        text="Bilagskontroll",
+        font=style.FONT_TITLE_HERO,
+        text_color=style.get_color("heading"),
+    )
+    app.header_title.grid(row=0, column=1, sticky="w")
+
+    app.header_tagline = ctk.CTkLabel(
+        brand,
+        text="Revisjonsklar innsikt på sekunder",
+        font=style.FONT_CAPTION,
+        text_color=style.get_color("muted"),
+    )
+    app.header_tagline.grid(row=1, column=1, sticky="w")
+
+    accent = ctk.CTkFrame(
+        head,
+        fg_color=style.get_color("accent"),
+        height=3,
+        corner_radius=style.CARD_RADIUS,
+    )
+    accent.grid(row=1, column=0, columnspan=9, sticky="ew", padx=style.PAD_XL, pady=(0, style.PAD_SM))
+    accent.grid_propagate(False)
+    app.header_accent = accent
+
+    metrics = ctk.CTkFrame(head, fg_color="transparent")
+    metrics.grid(
+        row=2,
+        column=0,
+        columnspan=9,
+        sticky="ew",
+        padx=style.PAD_XL,
+        pady=(0, style.PAD_LG),
+    )
+    metrics.grid_columnconfigure(6, weight=1)
+    app.header_metrics = metrics
+
+    app.lbl_count = ctk.CTkLabel(
+        metrics,
+        text="Bilag: –/–",
+        font=style.FONT_TITLE,
+        text_color=style.get_color("heading"),
+    )
+    app.lbl_count.grid(row=0, column=0, padx=(0, style.PAD_LG))
+
+    status_frame = ctk.CTkFrame(metrics, fg_color="transparent")
+    status_frame.grid(row=0, column=1, padx=(0, style.PAD_MD), sticky="w")
+    app.lbl_status_label = ctk.CTkLabel(
+        status_frame,
+        text="Status:",
+        font=style.FONT_TITLE_LITE,
+        text_color=style.get_color("muted"),
+    )
     app.lbl_status_label.grid(row=0, column=0, padx=(0, style.PAD_XXS))
     app.lbl_status = ctk.CTkLabel(
         status_frame,
         text="–",
-        font=head_font,
-        text_color=style.get_color("fg"),
+        font=style.FONT_TITLE_LITE,
+        text_color=style.get_color("heading"),
     )
     app.lbl_status.grid(row=0, column=1)
-    app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
-    app.lbl_count.grid(row=0, column=0, padx=(style.PAD_XS, style.PAD_LG))
-    app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
-    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
+
+    app.lbl_invoice = ctk.CTkLabel(
+        metrics,
+        text="Fakturanr: –",
+        font=style.FONT_TITLE_LITE,
+        text_color=style.get_color("muted"),
+    )
+    app.lbl_invoice.grid(row=0, column=2, padx=(0, style.PAD_MD))
+
+    create_button(
+        metrics,
+        text="📋 Kopier fakturanr",
+        command=app.copy_invoice,
+    ).grid(row=0, column=3, padx=(0, style.PAD_MD))
+
     app.copy_feedback = ctk.CTkLabel(
-        head,
+        metrics,
         text="",
-        text_color=style.get_color("success"),
+        text_color=style.get_color("accent"),
         font=style.FONT_BODY,
     )
-    app.copy_feedback.grid(row=0, column=4, padx=style.PAD_MD, sticky="w")
+    app.copy_feedback.grid(row=0, column=4, padx=(0, style.PAD_MD), sticky="w")
 
     app.inline_status = ctk.CTkLabel(
-        head,
+        metrics,
         text="",
         text_color=style.get_color("success"),
         font=style.FONT_BODY,
     )
-    app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
+    app.inline_status.grid(row=0, column=5, padx=(0, style.PAD_MD), sticky="e")
 
-    ctk.CTkLabel(head, text="Temavalg", font=style.FONT_BODY).grid(
-        row=0,
-        column=7,
-        padx=(style.PAD_MD, style.PAD_XS),
+    theme_label = ctk.CTkLabel(
+        metrics,
+        text="Temavalg",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     )
+    theme_label.grid(row=0, column=7, padx=(0, style.PAD_XS))
+    app.theme_label = theme_label
     default_theme_label = DEFAULT_APPEARANCE_MODE.title()
     app.theme_var = ctk.StringVar(value=default_theme_label)
     app.theme_menu = ctk.CTkOptionMenu(
-        head,
+        metrics,
         variable=app.theme_var,
         values=["Light", "Dark"],
         command=app._switch_theme,
@@ -72,9 +160,23 @@ def build_action_buttons(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    btns = ctk.CTkFrame(panel)
+    btns = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
     btns.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
     btns.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
+    app.action_frame = btns
+
+    ctk.CTkLabel(
+        btns,
+        text="Handlinger",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("heading"),
+    ).grid(row=0, column=0, columnspan=5, sticky="w", padx=style.PAD_XL, pady=(style.PAD_LG, style.PAD_SM))
 
     create_button(
         btns,
@@ -82,19 +184,23 @@ def build_action_buttons(app):
         fg_color=style.get_color("success"),
         hover_color=style.get_color("success_hover"),
         command=lambda: app.set_decision_and_next("Godkjent"),
-    ).grid(row=0, column=0, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    ).grid(row=1, column=0, padx=style.PAD_SM, pady=(0, style.PAD_LG), sticky="ew")
     create_button(
         btns,
         text="⛔ Ikke godkjent",
         fg_color=style.get_color("error"),
         hover_color=style.get_color("error_hover"),
         command=lambda: app.set_decision_and_next("Ikke godkjent"),
-    ).grid(row=0, column=1, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    create_button(btns, text="🔗 Åpne PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    ).grid(row=1, column=1, padx=style.PAD_SM, pady=(0, style.PAD_LG), sticky="ew")
+    create_button(
+        btns,
+        text="🔗 Åpne PowerOffice",
+        command=app.open_in_po,
+    ).grid(row=1, column=2, padx=style.PAD_SM, pady=(0, style.PAD_LG), sticky="ew")
     app.btn_prev = create_button(btns, text="⬅ Forrige", command=app.prev)
-    app.btn_prev.grid(row=0, column=3, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    app.btn_prev.grid(row=1, column=3, padx=style.PAD_SM, pady=(0, style.PAD_LG), sticky="ew")
     app.btn_next = create_button(btns, text="➡ Neste", command=app.next)
-    app.btn_next.grid(row=0, column=4, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    app.btn_next.grid(row=1, column=4, padx=style.PAD_SM, pady=(0, style.PAD_LG), sticky="ew")
 
     return btns
 
@@ -105,33 +211,76 @@ def build_panes(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    paned = ctk.CTkFrame(panel)
+    paned = ctk.CTkFrame(panel, fg_color="transparent")
     paned.grid(row=2, column=0, sticky="nsew", padx=style.PAD_LG, pady=(style.PAD_XS, style.PAD_SM))
     paned.grid_columnconfigure((0, 1), weight=1, minsize=400)
     paned.grid_rowconfigure(0, weight=1)
 
-    left = ctk.CTkFrame(paned)
-    right = ctk.CTkFrame(paned)
-    left.grid(row=0, column=0, sticky="nsew")
-    right.grid(row=0, column=1, sticky="nsew")
+    left = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
+    right = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
+    left.grid(row=0, column=0, sticky="nsew", padx=(0, style.PAD_SM))
+    right.grid(row=0, column=1, sticky="nsew", padx=(style.PAD_SM, 0))
+    app.detail_frame = left
     app.right_frame = right
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    ctk.CTkLabel(
+        left,
+        text="Detaljer for bilag",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("heading"),
+    ).grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_LG, style.PAD_XS))
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
     app.detail_box = ctk.CTkTextbox(left, height=360, font=style.FONT_BODY)
-    app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(style.PAD_MD, style.PAD_SM), pady=(0, style.PAD_MD))
+    app.detail_box.grid(
+        row=1,
+        column=0,
+        sticky="nsew",
+        padx=(style.PAD_MD, style.PAD_SM),
+        pady=(0, style.PAD_LG),
+    )
+    app.detail_box.configure(
+        fg_color=style.get_color("surface_alt"),
+        text_color=style.get_color("fg"),
+        border_width=0,
+    )
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    ctk.CTkLabel(
+        right,
+        text="Hovedbok (bilagslinjer)",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("heading"),
+    ).grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_LG, style.PAD_XS))
     right.grid_columnconfigure(0, weight=1)
     right.grid_columnconfigure(1, weight=0)
     right.grid_rowconfigure(1, weight=3, minsize=150)
     right.grid_rowconfigure(5, weight=1, minsize=120)
 
-    ctk.CTkLabel(right, text="Kommentar", font=style.FONT_TITLE_SMALL)\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(style.PAD_MD, style.PAD_SM), pady=(style.PAD_MD, style.PAD_XS))
+    ctk.CTkLabel(
+        right,
+        text="Kommentar",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("heading"),
+    ).grid(
+        row=4,
+        column=0,
+        columnspan=2,
+        sticky="w",
+        padx=(style.PAD_MD, style.PAD_SM),
+        pady=(style.PAD_MD, style.PAD_XS),
+    )
     app.comment_box = ctk.CTkTextbox(right, font=style.FONT_SMALL)
     app.comment_box.grid(
         row=5,
@@ -139,7 +288,12 @@ def build_panes(app):
         columnspan=2,
         sticky="nsew",
         padx=(style.PAD_MD, style.PAD_SM),
-        pady=(0, style.PAD_MD),
+        pady=(0, style.PAD_LG),
+    )
+    app.comment_box.configure(
+        fg_color=style.get_color("surface_alt"),
+        text_color=style.get_color("fg"),
+        border_width=0,
     )
 
     return paned
@@ -151,10 +305,23 @@ def build_bottom(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    bottom = ctk.CTkFrame(panel)
+    bottom = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
     bottom.grid(row=3, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_MD))
     bottom.grid_columnconfigure(1, weight=1)
     app.bottom_frame = bottom
+
+    ctk.CTkLabel(
+        bottom,
+        text="Rapportering",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("heading"),
+    ).grid(row=0, column=0, columnspan=3, sticky="w", padx=style.PAD_XL, pady=(style.PAD_LG, style.PAD_SM))
 
     def _export_pdf():
         from report import export_pdf
@@ -175,23 +342,26 @@ def build_bottom(app):
 
         run_in_thread(worker)
 
-    export_btn = create_button(
-        bottom, text="📄 Eksporter PDF rapport", command=_export_pdf
-    )
+    export_btn = create_button(bottom, text="📄 Eksporter PDF rapport", command=_export_pdf)
     export_btn.grid(
-        row=0,
+        row=1,
         column=0,
         padx=(style.PAD_MD, style.PAD_SM),
-        pady=style.PAD_SM,
+        pady=(0, style.PAD_LG),
         sticky="w",
     )
 
-    app.status_label = ctk.CTkLabel(bottom, text="", font=style.FONT_BODY)
+    app.status_label = ctk.CTkLabel(
+        bottom,
+        text="",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    )
     app.status_label.grid(
-        row=0,
+        row=1,
         column=1,
         padx=style.PAD_SM,
-        pady=style.PAD_SM,
+        pady=(0, style.PAD_LG),
         sticky="ew",
     )
 
@@ -199,14 +369,14 @@ def build_bottom(app):
         bottom,
         width=120,
         progress_color=style.get_color("success"),
-        fg_color=style.get_color("bg"),
+        fg_color=style.get_color("surface_alt"),
     )
     app.progress_bar.set(0)
     app.progress_bar_grid = {
-        "row": 0,
+        "row": 1,
         "column": 2,
         "padx": style.PAD_SM,
-        "pady": style.PAD_SM,
+        "pady": (0, style.PAD_LG),
         "sticky": "e",
     }
 
@@ -218,7 +388,13 @@ def build_main(app):
 
     import customtkinter as ctk
 
-    panel = ctk.CTkFrame(app, corner_radius=16)
+    panel = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
     panel.grid(row=0, column=1, sticky="nsew", padx=(0, style.PAD_XL), pady=style.PAD_XL)
     panel.grid_columnconfigure(0, weight=1)
     panel.grid_rowconfigure(2, weight=1, minsize=300)
@@ -306,6 +482,7 @@ def build_ledger_widgets(app):
         anchor="e",
         justify="right",
         font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     )
     app.ledger_sum.grid(
         row=3,

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -27,15 +27,54 @@ def _toggle_sample_btn(app, *_):
 def build_sidebar(app):
     import customtkinter as ctk
 
-    card = ctk.CTkFrame(app, corner_radius=16)
+    card = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("sidebar_bg"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
     card.grid(row=0, column=0, sticky="nsw", padx=style.PAD_XL, pady=style.PAD_XL)
+    card.grid_columnconfigure(0, weight=1)
+    app.sidebar_card = card
+    app.sidebar_labels = []
+    heading_label = ctk.CTkLabel(
+        card,
+        text="⚙️ Datautvalg",
+        font=style.FONT_TITLE_LARGE,
+        text_color=style.get_color("heading"),
+    )
+    heading_label.grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_XXS), sticky="w")
+    app.sidebar_labels.append((heading_label, "heading"))
 
-    ctk.CTkLabel(card, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE)\
-        .grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
+    subtitle_label = ctk.CTkLabel(
+        card,
+        text="Velg hvilke filer som skal kvalitetssikres.",
+        font=style.FONT_CAPTION,
+        text_color=style.get_color("muted"),
+    )
+    subtitle_label.grid(row=1, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="w")
+    app.sidebar_labels.append((subtitle_label, "muted"))
+
+    sources_card = ctk.CTkFrame(
+        card,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
+    sources_card.grid(row=2, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
+    sources_card.grid_columnconfigure(0, weight=1)
+    app.sources_card = sources_card
 
     app.file_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
-        .grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
+
+    create_button(
+        sources_card,
+        text="Velg leverandørfakturaer (Excel)…",
+        command=app.choose_file,
+    ).grid(row=0, column=0, padx=style.PAD_LG, pady=(style.PAD_LG, style.PAD_XS), sticky="ew")
+
     def _drop_invoice(event):
         path = parse_dropped_path(event)
         if not path:
@@ -43,20 +82,26 @@ def build_sidebar(app):
         app.file_path_var.set(path)
         app._load_excel()
 
-    app.inv_drop = DropZone(card, "Dra og slipp fakturaliste her", _drop_invoice)
-    app.inv_drop.grid(row=2, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
-    ctk.CTkLabel(
-        card,
+    app.inv_drop = DropZone(sources_card, "Dra og slipp fakturaliste her", _drop_invoice)
+    app.inv_drop.grid(row=1, column=0, padx=style.PAD_LG, pady=(0, style.PAD_XS), sticky="ew")
+    app.invoice_path_label = ctk.CTkLabel(
+        sources_card,
         textvariable=app.file_path_var,
         wraplength=260,
         anchor="w",
         justify="left",
-        font=style.FONT_BODY,
-    ).grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    )
+    app.invoice_path_label.grid(row=2, column=0, padx=style.PAD_LG, pady=(0, style.PAD_SM), sticky="ew")
+    app.sidebar_labels.append((app.invoice_path_label, "muted"))
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
-        .grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
+    create_button(
+        sources_card,
+        text="Velg hovedbok (Excel)…",
+        command=app.choose_gl_file,
+    ).grid(row=3, column=0, padx=style.PAD_LG, pady=(0, style.PAD_XS), sticky="ew")
 
     def _drop_gl(event):
         path = parse_dropped_path(event)
@@ -65,25 +110,52 @@ def build_sidebar(app):
         app.gl_path_var.set(path)
         app._load_gl_excel()
 
-    app.gl_drop = DropZone(card, "Dra og slipp hovedbok her", _drop_gl)
-    app.gl_drop.grid(row=5, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
-    ctk.CTkLabel(
-        card,
+    app.gl_drop = DropZone(sources_card, "Dra og slipp hovedbok her", _drop_gl)
+    app.gl_drop.grid(row=4, column=0, padx=style.PAD_LG, pady=(0, style.PAD_XS), sticky="ew")
+    app.gl_path_label = ctk.CTkLabel(
+        sources_card,
         textvariable=app.gl_path_var,
         wraplength=260,
         anchor="w",
         justify="left",
-        font=style.FONT_BODY,
-    ).grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+        font=style.FONT_SMALL,
+        text_color=style.get_color("muted"),
+    )
+    app.gl_path_label.grid(row=5, column=0, padx=style.PAD_LG, pady=(0, style.PAD_LG), sticky="ew")
+    app.sidebar_labels.append((app.gl_path_label, "muted"))
 
     app.add_drop_target(app.inv_drop, app.inv_drop.on_drop)
     app.add_drop_target(app.gl_drop, app.gl_drop.on_drop)
 
-    row_utv = ctk.CTkFrame(card)
-    row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")
-    ctk.CTkLabel(row_utv, text="Antall tilfeldig utvalg", font=style.FONT_BODY).grid(
-        row=0, column=0, padx=(style.PAD_MD, 0), sticky="w"
+    sample_card = ctk.CTkFrame(
+        card,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
     )
+    sample_card.grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
+    sample_card.grid_columnconfigure(0, weight=1)
+    sample_card.grid_columnconfigure(1, weight=1)
+    app.sample_card = sample_card
+
+    app.sample_title_label = ctk.CTkLabel(
+        sample_card,
+        text="Stikkprøve",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("heading"),
+    )
+    app.sample_title_label.grid(row=0, column=0, columnspan=2, padx=style.PAD_LG, pady=(style.PAD_LG, style.PAD_XS), sticky="w")
+    app.sidebar_labels.append((app.sample_title_label, "heading"))
+
+    app.sample_count_label = ctk.CTkLabel(
+        sample_card,
+        text="Antall tilfeldig utvalg",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    )
+    app.sample_count_label.grid(row=1, column=0, padx=style.PAD_LG, pady=(0, style.PAD_XXS), sticky="w")
+    app.sidebar_labels.append((app.sample_count_label, "muted"))
 
     def _validate_int(P: str) -> bool:
         return P.isdigit() or P == ""
@@ -91,74 +163,124 @@ def build_sidebar(app):
     vcmd_int = app.register(_validate_int)
     app.sample_size_var = ctk.StringVar(master=app, value="")
     ctk.CTkEntry(
-        row_utv,
-        width=80,
+        sample_card,
+        width=100,
         textvariable=app.sample_size_var,
         validate="key",
         validatecommand=(vcmd_int, "%P"),
-    ).grid(row=0, column=1, padx=(style.PAD_MD, 0))
+    ).grid(row=1, column=1, padx=(style.PAD_SM, style.PAD_LG), pady=(0, style.PAD_XXS), sticky="ew")
 
-    ctk.CTkLabel(row_utv, text="År", font=style.FONT_BODY).grid(
-        row=1,
-        column=0,
-        padx=(style.PAD_MD, 0),
-        pady=(style.PAD_SM, 0),
-        sticky="w",
+    app.sample_year_label = ctk.CTkLabel(
+        sample_card,
+        text="År",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
     )
+    app.sample_year_label.grid(row=2, column=0, padx=style.PAD_LG, pady=(style.PAD_SM, 0), sticky="w")
+    app.sidebar_labels.append((app.sample_year_label, "muted"))
 
     app.year_var = ctk.StringVar(master=app, value="")
     app.year_combo = ctk.CTkComboBox(
-        row_utv,
-        width=80,
+        sample_card,
+        width=100,
         variable=app.year_var,
         values=[],
         state="readonly",
         command=lambda _: _toggle_sample_btn(app),
     )
-    app.year_combo.grid(row=1, column=1, padx=(style.PAD_MD, 0), pady=(style.PAD_SM, 0))
+    app.year_combo.grid(row=2, column=1, padx=(style.PAD_SM, style.PAD_LG), pady=(style.PAD_SM, 0), sticky="ew")
 
-    app.sample_btn = create_button(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
-    app.sample_btn.grid(row=8, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_SM), sticky="ew")
+    app.sample_btn = create_button(
+        sample_card,
+        text="🎲 Lag utvalg",
+        command=app.make_sample,
+        state="disabled",
+    )
+    app.sample_btn.grid(row=3, column=0, columnspan=2, padx=style.PAD_LG, pady=(style.PAD_MD, style.PAD_LG), sticky="ew")
 
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
     app._update_year_options()
 
-    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=style.FONT_TITLE)
-    app.lbl_filecount.grid(row=9, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="w")
+    app.lbl_filecount = ctk.CTkLabel(
+        card,
+        text="Antall bilag: –",
+        font=style.FONT_TITLE,
+        text_color=style.get_color("heading"),
+    )
+    app.lbl_filecount.grid(row=4, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="w")
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.FONT_BODY_BOLD)\
-        .grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
-    opp = ctk.CTkFrame(card, corner_radius=8)
-    opp.grid(row=11, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
+    opp_label = ctk.CTkLabel(
+        card,
+        text="Oppdragsinfo",
+        font=style.FONT_TITLE_SMALL,
+        text_color=style.get_color("heading"),
+    )
+    opp_label.grid(row=5, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XS), sticky="w")
+    app.sidebar_labels.append((opp_label, "heading"))
+    opp = ctk.CTkFrame(
+        card,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
+    opp.grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
     opp.grid_columnconfigure(0, weight=0)
     opp.grid_columnconfigure(1, weight=1)
+    app.assignment_card = opp
 
     app.kunde_var = ctk.StringVar(master=app, value="")
     default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
     app.utfort_av_var = ctk.StringVar(master=app, value=default_user)
 
-    ctk.CTkLabel(opp, text="Kunde", font=style.FONT_BODY).grid(
+    kunde_label = ctk.CTkLabel(
+        opp,
+        text="Kunde",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    )
+    kunde_label.grid(
         row=0,
         column=0,
-        padx=(style.PAD_MD, style.PAD_MD),
-        pady=(style.PAD_MD, style.PAD_XS),
+        padx=(style.PAD_LG, style.PAD_MD),
+        pady=(style.PAD_LG, style.PAD_XS),
         sticky="w",
     )
+    app.sidebar_labels.append((kunde_label, "muted"))
     app.kunde_entry = ctk.CTkEntry(
         opp,
         textvariable=app.kunde_var,
         placeholder_text="Hentes automatisk",
         state="disabled",
     )
-    app.kunde_entry.grid(row=0, column=1, padx=(0, style.PAD_MD), pady=(style.PAD_MD, style.PAD_XS), sticky="ew")
-    ctk.CTkLabel(opp, text="Utført av", font=style.FONT_BODY).grid(
+    app.kunde_entry.grid(
+        row=0,
+        column=1,
+        padx=(0, style.PAD_LG),
+        pady=(style.PAD_LG, style.PAD_XS),
+        sticky="ew",
+    )
+    utf_label = ctk.CTkLabel(
+        opp,
+        text="Utført av",
+        font=style.FONT_BODY,
+        text_color=style.get_color("muted"),
+    )
+    utf_label.grid(
         row=1,
         column=0,
-        padx=(style.PAD_MD, style.PAD_MD),
-        pady=(style.PAD_XS, style.PAD_MD),
+        padx=(style.PAD_LG, style.PAD_MD),
+        pady=(style.PAD_XS, style.PAD_LG),
         sticky="w",
     )
-    ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(row=1, column=1, padx=(0, style.PAD_MD), pady=(style.PAD_XS, style.PAD_MD), sticky="ew")
+    app.sidebar_labels.append((utf_label, "muted"))
+    ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(
+        row=1,
+        column=1,
+        padx=(0, style.PAD_LG),
+        pady=(style.PAD_XS, style.PAD_LG),
+        sticky="ew",
+    )
     info_lbl = ctk.CTkLabel(
         opp,
         text="Kundenavn hentes automatisk",
@@ -166,43 +288,110 @@ def build_sidebar(app):
         anchor="w",
         justify="left",
         wraplength=240,
+        text_color=style.get_color("muted_alt"),
     )
-    info_lbl.grid(row=2, column=0, columnspan=2, padx=(style.PAD_MD, style.PAD_MD), pady=(0, style.PAD_MD), sticky="w")
+    info_lbl.grid(
+        row=2,
+        column=0,
+        columnspan=2,
+        padx=(style.PAD_LG, style.PAD_LG),
+        pady=(0, style.PAD_LG),
+        sticky="w",
+    )
+    app.assignment_hint_label = info_lbl
+    app.sidebar_labels.append((info_lbl, "muted_alt"))
 
-    card.grid_rowconfigure(20, weight=1)
+    card.grid_rowconfigure(40, weight=1)
 
-    status_card = ctk.CTkFrame(card, corner_radius=12)
+    status_card = ctk.CTkFrame(
+        card,
+        corner_radius=style.SECTION_RADIUS,
+        fg_color=style.get_color("surface"),
+        border_width=1,
+        border_color=style.get_color("border"),
+    )
     status_card.grid(
         row=100,
         column=0,
         padx=style.PAD_XL,
-        pady=(style.PAD_MD, PADDING_Y),
+        pady=(style.PAD_SM, PADDING_Y),
         sticky="ew",
     )
     status_card.grid_columnconfigure(0, weight=1)
+    app.status_card = status_card
 
-    title_font = style.FONT_TITLE_LARGE
+    title_font = style.FONT_TITLE_SMALL
     body_font = style.FONT_BODY
 
-    ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
-        .grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
+    app.status_title_label = ctk.CTkLabel(
+        status_card,
+        text="Status",
+        font=title_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("heading"),
+    )
+    app.status_title_label.grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
+    app.sidebar_labels.append((app.status_title_label, "heading"))
 
-    app.lbl_st_sum_kontrollert = ctk.CTkLabel(status_card, text="Sum kontrollert: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_kontrollert = ctk.CTkLabel(
+        status_card,
+        text="Sum kontrollert: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_sum_kontrollert.grid(row=1, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_sum_alle = ctk.CTkLabel(status_card, text="Sum alle bilag: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_sum_alle = ctk.CTkLabel(
+        status_card,
+        text="Sum alle bilag: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_sum_alle.grid(row=2, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_pct = ctk.CTkLabel(status_card, text="% kontrollert av sum: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_pct = ctk.CTkLabel(
+        status_card,
+        text="% kontrollert av sum: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_pct.grid(row=3, column=0, sticky="ew", pady=(0, style.PAD_MD))
 
-    app.lbl_st_godkjent = ctk.CTkLabel(status_card, text="Godkjent: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_godkjent = ctk.CTkLabel(
+        status_card,
+        text="Godkjent: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_godkjent.grid(row=4, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_ikkegodkjent = ctk.CTkLabel(status_card, text="Ikke godkjent: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_ikkegodkjent = ctk.CTkLabel(
+        status_card,
+        text="Ikke godkjent: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_ikkegodkjent.grid(row=5, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
-    app.lbl_st_gjen = ctk.CTkLabel(status_card, text="Gjenstår å kontrollere: –", font=body_font, anchor="center", justify="center")
+    app.lbl_st_gjen = ctk.CTkLabel(
+        status_card,
+        text="Gjenstår å kontrollere: –",
+        font=body_font,
+        anchor="center",
+        justify="center",
+        text_color=style.get_color("muted"),
+    )
     app.lbl_st_gjen.grid(row=6, column=0, sticky="ew", pady=(style.PAD_SM, PADDING_Y))
 
     try:
@@ -235,3 +424,4 @@ def build_sidebar(app):
         logger.exception("Kunne ikke laste sidebar-logo")
 
     return card
+

--- a/gui/style.py
+++ b/gui/style.py
@@ -12,9 +12,13 @@ class Style:
     """Samler felles stilkonfigurasjon for GUI."""
 
     # Knappestil
-    BTN_FG: str = "#1f6aa5"
-    BTN_HOVER: str = "#185a8b"
-    BTN_RADIUS: int = 8
+    BTN_FG: str = "#0f4c81"
+    BTN_HOVER: str = "#0d3e6a"
+    BTN_RADIUS: int = 10
+
+    # Generelle hjørneradier
+    CARD_RADIUS: int = 16
+    SECTION_RADIUS: int = 12
 
     # Farger per tema
     COLORS: Dict[str, Dict[str, str]] = field(
@@ -25,10 +29,22 @@ class Style:
             "error_hover": {"light": "#cf4334", "dark": "#992d22"},
             # Generelle farger
             "bg": {"light": "#ffffff", "dark": "#1e1e1e"},
-            "fg": {"light": "#000000", "dark": "#e6e6e6"},
+            "fg": {"light": "#0f1927", "dark": "#f2f5fa"},
+            "app_bg": {"light": "#eef2f7", "dark": "#0f141d"},
+            "surface": {"light": "#ffffff", "dark": "#1b2332"},
+            "surface_alt": {"light": "#f5f8fc", "dark": "#222b3d"},
+            "sidebar_bg": {"light": "#f3f6fb", "dark": "#181f2c"},
+            "border": {"light": "#d2d9e6", "dark": "#2c3547"},
+            "heading": {"light": "#0f1927", "dark": "#f5f8ff"},
+            "muted": {"light": "#5a6a7d", "dark": "#aebad1"},
+            "muted_alt": {"light": "#72829a", "dark": "#90a0bb"},
+            "accent": {"light": "#0f4c81", "dark": "#3f8cff"},
+            "accent_hover": {"light": "#0d3e6a", "dark": "#306ed6"},
+            "accent_subtle": {"light": "#d6e4f8", "dark": "#1f2f47"},
+            "button_text": {"light": "#ffffff", "dark": "#ffffff"},
             # Dra-og-slipp felt
-            "dnd_bg": {"light": "#f5f6f7", "dark": "#2b2b2b"},
-            "dnd_border": {"light": "#a8b1bb", "dark": "#4a4f55"},
+            "dnd_bg": {"light": "#e1e7f2", "dark": "#263247"},
+            "dnd_border": {"light": "#9fb0c9", "dark": "#3b4962"},
             # Tabellfarger
             "table_bg": {"light": "#ffffff", "dark": "#1e1e1e"},
             "table_fg": {"light": "#000000", "dark": "#e6e6e6"},
@@ -59,16 +75,18 @@ class Style:
             raise KeyError(f"Ukjent fargenavn: {name}") from e
 
     # Skrifttyper
-    FONT_FAMILY: str = "Helvetica"
+    FONT_FAMILY: str = "Segoe UI"
     # Skrifttyper (initialiseres lazily)
     FONT_TITLE: Optional[object] = None
     FONT_BODY: Optional[object] = None
     FONT_TITLE_LITE: Optional[object] = None
     FONT_TITLE_LARGE: Optional[object] = None
     FONT_TITLE_SMALL: Optional[object] = None
+    FONT_TITLE_HERO: Optional[object] = None
     FONT_BODY_BOLD: Optional[object] = None
     FONT_SMALL: Optional[object] = None
     FONT_SMALL_ITALIC: Optional[object] = None
+    FONT_CAPTION: Optional[object] = None
 
     # Standard spacing
     PAD_XL: int = 14


### PR DESCRIPTION
## Oppsummering
- innførte nytt fargepalett, skrifttyper og hjørneradier for knapper og kort for å gi et mer profesjonelt uttrykk
- redesignet hovedpanel, toppseksjon, handlingsknapper og bunnkort med kortestetikk, statuslinjer og tydeligere hierarki
- moderniserte sidepanelet med seksjonskort, nye dra-og-slipp-soner og statusfelter som følger temaendringer
- la til en felles `refresh_theme_colors`-rutine som oppdaterer farger ved temabytte og når UI-et bygges

## Tester
- `pytest` *(feilet: mangler pandas/openpyxl)*

------
https://chatgpt.com/codex/tasks/task_e_68ff21959ea08328a9c38094262e5771