### PR TITLE
Forbedre GUI med kort-layout og aksentfarger

### DIFF
--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -9,15 +9,35 @@ def build_header(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    head = ctk.CTkFrame(panel)
-    head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
-    head.grid_columnconfigure(6, weight=1)
+    head = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
+    head.grid(
+        row=0,
+        column=0,
+        sticky="ew",
+        padx=style.PAD_LG,
+        pady=(style.PAD_LG, style.PAD_SM),
+    )
+    head.grid_columnconfigure(0, weight=1)
+
+    accent = ctk.CTkFrame(head, height=6, fg_color=style.get_color("accent"))
+    accent.grid(row=0, column=0, sticky="ew")
+    accent.grid_propagate(False)
+
+    content = ctk.CTkFrame(head, fg_color="transparent")
+    content.grid(row=1, column=0, sticky="ew", padx=style.PAD_XL, pady=style.PAD_MD)
+    content.grid_columnconfigure(5, weight=1)
 
     head_font = style.FONT_TITLE_LITE
 
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.FONT_TITLE)
-    status_frame = ctk.CTkFrame(head, fg_color="transparent")
-    status_frame.grid(row=0, column=1, padx=style.PAD_MD, sticky="w")
+    app.lbl_count = ctk.CTkLabel(content, text="Bilag: –/–", font=style.FONT_TITLE)
+    status_frame = ctk.CTkFrame(content, fg_color="transparent")
+    status_frame.grid(row=0, column=1, padx=(style.PAD_SM, style.PAD_LG), sticky="w")
     app.lbl_status_label = ctk.CTkLabel(status_frame, text="Status:", font=head_font)
     app.lbl_status_label.grid(row=0, column=0, padx=(0, style.PAD_XXS))
     app.lbl_status = ctk.CTkLabel(
@@ -27,40 +47,44 @@ def build_header(app):
         text_color=style.get_color("fg"),
     )
     app.lbl_status.grid(row=0, column=1)
-    app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
-    app.lbl_count.grid(row=0, column=0, padx=(style.PAD_XS, style.PAD_LG))
-    app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
-    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
+    app.lbl_invoice = ctk.CTkLabel(content, text="Fakturanr: –", font=head_font)
+    app.lbl_count.grid(row=0, column=0, padx=(0, style.PAD_SM))
+    app.lbl_invoice.grid(row=0, column=2, padx=(0, style.PAD_MD))
+    create_button(content, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(
+        row=0,
+        column=3,
+        padx=(style.PAD_MD, style.PAD_SM),
+    )
     app.copy_feedback = ctk.CTkLabel(
-        head,
+        content,
         text="",
         text_color=style.get_color("success"),
         font=style.FONT_BODY,
     )
-    app.copy_feedback.grid(row=0, column=4, padx=style.PAD_MD, sticky="w")
+    app.copy_feedback.grid(row=0, column=4, padx=(0, style.PAD_SM), sticky="w")
 
     app.inline_status = ctk.CTkLabel(
-        head,
+        content,
         text="",
         text_color=style.get_color("success"),
         font=style.FONT_BODY,
     )
-    app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
+    app.inline_status.grid(row=0, column=5, padx=(0, style.PAD_LG), sticky="e")
 
-    ctk.CTkLabel(head, text="Temavalg", font=style.FONT_BODY).grid(
+    ctk.CTkLabel(content, text="Temavalg", font=style.FONT_BODY).grid(
         row=0,
-        column=7,
-        padx=(style.PAD_MD, style.PAD_XS),
+        column=6,
+        padx=(0, style.PAD_XS),
     )
     default_theme_label = DEFAULT_APPEARANCE_MODE.title()
     app.theme_var = ctk.StringVar(value=default_theme_label)
     app.theme_menu = ctk.CTkOptionMenu(
-        head,
+        content,
         variable=app.theme_var,
         values=["Light", "Dark"],
         command=app._switch_theme,
     )
-    app.theme_menu.grid(row=0, column=8, padx=(0, style.PAD_MD))
+    app.theme_menu.grid(row=0, column=7, padx=(0, style.PAD_XS))
     app.theme_menu.set(default_theme_label)
 
     return head
@@ -72,29 +96,50 @@ def build_action_buttons(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    btns = ctk.CTkFrame(panel)
-    btns.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
-    btns.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
+    btns = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
+    btns.grid(
+        row=1,
+        column=0,
+        sticky="ew",
+        padx=style.PAD_LG,
+        pady=(0, style.PAD_MD),
+    )
+    btns.grid_columnconfigure(0, weight=1)
+
+    toolbar = ctk.CTkFrame(btns, fg_color="transparent")
+    toolbar.grid(row=0, column=0, sticky="ew", padx=style.PAD_XL, pady=style.PAD_MD)
+    toolbar.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
 
     create_button(
-        btns,
+        toolbar,
         text="✅ Godkjent",
         fg_color=style.get_color("success"),
         hover_color=style.get_color("success_hover"),
         command=lambda: app.set_decision_and_next("Godkjent"),
-    ).grid(row=0, column=0, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    ).grid(row=0, column=0, padx=(0, style.PAD_SM), sticky="ew")
     create_button(
-        btns,
+        toolbar,
         text="⛔ Ikke godkjent",
         fg_color=style.get_color("error"),
         hover_color=style.get_color("error_hover"),
         command=lambda: app.set_decision_and_next("Ikke godkjent"),
-    ).grid(row=0, column=1, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    create_button(btns, text="🔗 Åpne PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    app.btn_prev = create_button(btns, text="⬅ Forrige", command=app.prev)
-    app.btn_prev.grid(row=0, column=3, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    app.btn_next = create_button(btns, text="➡ Neste", command=app.next)
-    app.btn_next.grid(row=0, column=4, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+    ).grid(row=0, column=1, padx=style.PAD_SM, sticky="ew")
+    create_button(toolbar, text="🔗 Åpne PowerOffice", command=app.open_in_po).grid(
+        row=0,
+        column=2,
+        padx=style.PAD_SM,
+        sticky="ew",
+    )
+    app.btn_prev = create_button(toolbar, text="⬅ Forrige", command=app.prev)
+    app.btn_prev.grid(row=0, column=3, padx=style.PAD_SM, sticky="ew")
+    app.btn_next = create_button(toolbar, text="➡ Neste", command=app.next)
+    app.btn_next.grid(row=0, column=4, padx=(style.PAD_SM, 0), sticky="ew")
 
     return btns
 
@@ -105,40 +150,105 @@ def build_panes(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    paned = ctk.CTkFrame(panel)
-    paned.grid(row=2, column=0, sticky="nsew", padx=style.PAD_LG, pady=(style.PAD_XS, style.PAD_SM))
+    paned = ctk.CTkFrame(panel, fg_color="transparent")
+    paned.grid(
+        row=2,
+        column=0,
+        sticky="nsew",
+        padx=style.PAD_LG,
+        pady=(0, style.PAD_MD),
+    )
     paned.grid_columnconfigure((0, 1), weight=1, minsize=400)
     paned.grid_rowconfigure(0, weight=1)
 
-    left = ctk.CTkFrame(paned)
-    right = ctk.CTkFrame(paned)
-    left.grid(row=0, column=0, sticky="nsew")
-    right.grid(row=0, column=1, sticky="nsew")
-    app.right_frame = right
+    left_card = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
+    left_card.grid(row=0, column=0, sticky="nsew", padx=(0, style.PAD_SM))
+    left_card.grid_rowconfigure(1, weight=1)
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    left_accent = ctk.CTkFrame(left_card, height=6, fg_color=style.get_color("accent"))
+    left_accent.grid(row=0, column=0, sticky="ew")
+    left_accent.grid_propagate(False)
+
+    left = ctk.CTkFrame(left_card, fg_color="transparent")
+    left.grid(row=1, column=0, sticky="nsew", padx=style.PAD_LG, pady=style.PAD_MD)
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
-    app.detail_box = ctk.CTkTextbox(left, height=360, font=style.FONT_BODY)
-    app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(style.PAD_MD, style.PAD_SM), pady=(0, style.PAD_MD))
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
+    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL).grid(
+        row=0,
+        column=0,
+        sticky="w",
+        pady=(0, style.PAD_SM),
+    )
+    app.detail_box = ctk.CTkTextbox(
+        left,
+        height=360,
+        font=style.FONT_BODY,
+        fg_color=style.get_color("bg"),
+        text_color=style.get_color("fg"),
+        border_width=0,
+    )
+    app.detail_box.grid(
+        row=1,
+        column=0,
+        sticky="nsew",
+        pady=(0, style.PAD_MD),
+    )
+
+    right_card = ctk.CTkFrame(
+        paned,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
+    right_card.grid(row=0, column=1, sticky="nsew", padx=(style.PAD_SM, 0))
+    right_card.grid_rowconfigure(1, weight=1)
+
+    right_accent = ctk.CTkFrame(right_card, height=6, fg_color=style.get_color("accent"))
+    right_accent.grid(row=0, column=0, sticky="ew")
+    right_accent.grid_propagate(False)
+
+    right = ctk.CTkFrame(right_card, fg_color="transparent")
+    right.grid(row=1, column=0, sticky="nsew", padx=style.PAD_LG, pady=style.PAD_MD)
     right.grid_columnconfigure(0, weight=1)
     right.grid_columnconfigure(1, weight=0)
     right.grid_rowconfigure(1, weight=3, minsize=150)
     right.grid_rowconfigure(5, weight=1, minsize=120)
+    app.right_frame = right
 
-    ctk.CTkLabel(right, text="Kommentar", font=style.FONT_TITLE_SMALL)\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(style.PAD_MD, style.PAD_SM), pady=(style.PAD_MD, style.PAD_XS))
-    app.comment_box = ctk.CTkTextbox(right, font=style.FONT_SMALL)
+    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL).grid(
+        row=0,
+        column=0,
+        sticky="w",
+        pady=(0, style.PAD_SM),
+    )
+
+    ctk.CTkLabel(right, text="Kommentar", font=style.FONT_TITLE_SMALL).grid(
+        row=4,
+        column=0,
+        columnspan=2,
+        sticky="w",
+        pady=(style.PAD_MD, style.PAD_XS),
+    )
+    app.comment_box = ctk.CTkTextbox(
+        right,
+        font=style.FONT_SMALL,
+        fg_color=style.get_color("bg"),
+        text_color=style.get_color("fg"),
+        border_width=0,
+    )
     app.comment_box.grid(
         row=5,
         column=0,
         columnspan=2,
         sticky="nsew",
-        padx=(style.PAD_MD, style.PAD_SM),
         pady=(0, style.PAD_MD),
     )
 
@@ -151,10 +261,27 @@ def build_bottom(app):
     import customtkinter as ctk
 
     panel = app.main_panel
-    bottom = ctk.CTkFrame(panel)
-    bottom.grid(row=3, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_MD))
-    bottom.grid_columnconfigure(1, weight=1)
-    app.bottom_frame = bottom
+    bottom = ctk.CTkFrame(
+        panel,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
+    bottom.grid(
+        row=3,
+        column=0,
+        sticky="ew",
+        padx=style.PAD_LG,
+        pady=(0, style.PAD_LG),
+    )
+    bottom.grid_columnconfigure(0, weight=1)
+
+    bottom_inner = ctk.CTkFrame(bottom, fg_color="transparent")
+    bottom_inner.grid(row=0, column=0, sticky="ew", padx=style.PAD_XL, pady=style.PAD_MD)
+    bottom_inner.grid_columnconfigure(1, weight=1)
+    bottom_inner.grid_columnconfigure(2, weight=0)
+    app.bottom_frame = bottom_inner
 
     def _export_pdf():
         from report import export_pdf
@@ -176,28 +303,26 @@ def build_bottom(app):
         run_in_thread(worker)
 
     export_btn = create_button(
-        bottom, text="📄 Eksporter PDF rapport", command=_export_pdf
+        bottom_inner, text="📄 Eksporter PDF rapport", command=_export_pdf
     )
     export_btn.grid(
         row=0,
         column=0,
-        padx=(style.PAD_MD, style.PAD_SM),
-        pady=style.PAD_SM,
+        padx=(0, style.PAD_SM),
         sticky="w",
     )
 
-    app.status_label = ctk.CTkLabel(bottom, text="", font=style.FONT_BODY)
+    app.status_label = ctk.CTkLabel(bottom_inner, text="", font=style.FONT_BODY)
     app.status_label.grid(
         row=0,
         column=1,
         padx=style.PAD_SM,
-        pady=style.PAD_SM,
         sticky="ew",
     )
 
     app.progress_bar = ctk.CTkProgressBar(
-        bottom,
-        width=120,
+        bottom_inner,
+        width=160,
         progress_color=style.get_color("success"),
         fg_color=style.get_color("bg"),
     )
@@ -205,8 +330,8 @@ def build_bottom(app):
     app.progress_bar_grid = {
         "row": 0,
         "column": 2,
-        "padx": style.PAD_SM,
-        "pady": style.PAD_SM,
+        "padx": (style.PAD_SM, 0),
+        "pady": 0,
         "sticky": "e",
     }
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -27,15 +27,44 @@ def _toggle_sample_btn(app, *_):
 def build_sidebar(app):
     import customtkinter as ctk
 
-    card = ctk.CTkFrame(app, corner_radius=16)
+    card = ctk.CTkFrame(
+        app,
+        corner_radius=style.CARD_RADIUS,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
     card.grid(row=0, column=0, sticky="nsw", padx=style.PAD_XL, pady=style.PAD_XL)
+    card.grid_columnconfigure(0, weight=1)
+    card.grid_rowconfigure(1, weight=1)
 
-    ctk.CTkLabel(card, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE)\
-        .grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
+    accent = ctk.CTkFrame(card, height=6, fg_color=style.get_color("accent"))
+    accent.grid(row=0, column=0, sticky="ew")
+    accent.grid_propagate(False)
+
+    content = ctk.CTkFrame(card, fg_color="transparent")
+    content.grid(
+        row=1,
+        column=0,
+        sticky="nsew",
+        padx=style.PAD_LG,
+        pady=(style.PAD_MD, style.PAD_LG),
+    )
+    content.grid_columnconfigure(0, weight=1)
+
+    ctk.CTkLabel(content, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE).grid(
+        row=0,
+        column=0,
+        sticky="w",
+        pady=(0, style.PAD_SM),
+    )
 
     app.file_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
-        .grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
+    create_button(
+        content,
+        text="Velg leverandørfakturaer (Excel)…",
+        command=app.choose_file,
+    ).grid(row=1, column=0, sticky="ew", pady=(0, style.PAD_XXS))
     def _drop_invoice(event):
         path = parse_dropped_path(event)
         if not path:
@@ -43,20 +72,23 @@ def build_sidebar(app):
         app.file_path_var.set(path)
         app._load_excel()
 
-    app.inv_drop = DropZone(card, "Dra og slipp fakturaliste her", _drop_invoice)
-    app.inv_drop.grid(row=2, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
+    app.inv_drop = DropZone(content, "Dra og slipp fakturaliste her", _drop_invoice)
+    app.inv_drop.grid(row=2, column=0, sticky="ew", pady=(0, style.PAD_XXS))
     ctk.CTkLabel(
-        card,
+        content,
         textvariable=app.file_path_var,
         wraplength=260,
         anchor="w",
         justify="left",
         font=style.FONT_BODY,
-    ).grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+    ).grid(row=3, column=0, sticky="ew", pady=(0, style.PAD_SM))
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
-        .grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
+    create_button(
+        content,
+        text="Velg hovedbok (Excel)…",
+        command=app.choose_gl_file,
+    ).grid(row=4, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
     def _drop_gl(event):
         path = parse_dropped_path(event)
@@ -65,22 +97,22 @@ def build_sidebar(app):
         app.gl_path_var.set(path)
         app._load_gl_excel()
 
-    app.gl_drop = DropZone(card, "Dra og slipp hovedbok her", _drop_gl)
-    app.gl_drop.grid(row=5, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
+    app.gl_drop = DropZone(content, "Dra og slipp hovedbok her", _drop_gl)
+    app.gl_drop.grid(row=5, column=0, sticky="ew", pady=(0, style.PAD_XXS))
     ctk.CTkLabel(
-        card,
+        content,
         textvariable=app.gl_path_var,
         wraplength=260,
         anchor="w",
         justify="left",
         font=style.FONT_BODY,
-    ).grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+    ).grid(row=6, column=0, sticky="ew", pady=(0, style.PAD_SM))
 
     app.add_drop_target(app.inv_drop, app.inv_drop.on_drop)
     app.add_drop_target(app.gl_drop, app.gl_drop.on_drop)
 
-    row_utv = ctk.CTkFrame(card)
-    row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")
+    row_utv = ctk.CTkFrame(content, fg_color="transparent")
+    row_utv.grid(row=7, column=0, sticky="ew", pady=(style.PAD_XS, 0))
     ctk.CTkLabel(row_utv, text="Antall tilfeldig utvalg", font=style.FONT_BODY).grid(
         row=0, column=0, padx=(style.PAD_MD, 0), sticky="w"
     )
@@ -117,19 +149,34 @@ def build_sidebar(app):
     )
     app.year_combo.grid(row=1, column=1, padx=(style.PAD_MD, 0), pady=(style.PAD_SM, 0))
 
-    app.sample_btn = create_button(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
-    app.sample_btn.grid(row=8, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_SM), sticky="ew")
+    app.sample_btn = create_button(
+        content,
+        text="🎲 Lag utvalg",
+        command=app.make_sample,
+        state="disabled",
+    )
+    app.sample_btn.grid(row=8, column=0, sticky="ew", pady=(style.PAD_MD, style.PAD_SM))
 
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
     app._update_year_options()
 
-    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=style.FONT_TITLE)
-    app.lbl_filecount.grid(row=9, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="w")
+    app.lbl_filecount = ctk.CTkLabel(content, text="Antall bilag: –", font=style.FONT_TITLE)
+    app.lbl_filecount.grid(row=9, column=0, sticky="w", pady=(style.PAD_XXS, style.PAD_XXS))
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.FONT_BODY_BOLD)\
-        .grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
-    opp = ctk.CTkFrame(card, corner_radius=8)
-    opp.grid(row=11, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
+    ctk.CTkLabel(content, text="Oppdragsinfo", font=style.FONT_BODY_BOLD).grid(
+        row=10,
+        column=0,
+        sticky="w",
+        pady=(style.PAD_MD, style.PAD_XXS),
+    )
+    opp = ctk.CTkFrame(
+        content,
+        corner_radius=12,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
+    opp.grid(row=11, column=0, sticky="ew", pady=(0, style.PAD_MD))
     opp.grid_columnconfigure(0, weight=0)
     opp.grid_columnconfigure(1, weight=1)
 
@@ -169,15 +216,20 @@ def build_sidebar(app):
     )
     info_lbl.grid(row=2, column=0, columnspan=2, padx=(style.PAD_MD, style.PAD_MD), pady=(0, style.PAD_MD), sticky="w")
 
-    card.grid_rowconfigure(20, weight=1)
+    content.grid_rowconfigure(40, weight=1)
 
-    status_card = ctk.CTkFrame(card, corner_radius=12)
+    status_card = ctk.CTkFrame(
+        content,
+        corner_radius=12,
+        fg_color=style.get_color("card_bg"),
+        border_width=1,
+        border_color=style.get_color("card_border"),
+    )
     status_card.grid(
         row=100,
         column=0,
-        padx=style.PAD_XL,
-        pady=(style.PAD_MD, PADDING_Y),
         sticky="ew",
+        pady=(style.PAD_MD, PADDING_Y),
     )
     status_card.grid_columnconfigure(0, weight=1)
 

--- a/gui/style.py
+++ b/gui/style.py
@@ -37,6 +37,10 @@ class Style:
             "table_sel_fg": {"light": "#000000", "dark": "#ffffff"},
             "table_row_odd": {"light": "#f6f6f6", "dark": "#232323"},
             "table_row_even": {"light": "#ffffff", "dark": "#1e1e1e"},
+            # Kort og paneler
+            "card_bg": {"light": "#f8fafc", "dark": "#252a30"},
+            "card_border": {"light": "#d9e0e7", "dark": "#3a4048"},
+            "accent": {"light": "#3c8dff", "dark": "#7aa2ff"},
         }
     )
 
@@ -77,6 +81,9 @@ class Style:
     PAD_SM: int = 6
     PAD_XS: int = 4
     PAD_XXS: int = 2
+
+    # Layout
+    CARD_RADIUS: int = 18
 
 
 style = Style()


### PR DESCRIPTION
## Sammendrag
- Gir hovedpanelet kort-inspirerte seksjoner med aksentlinjer og bedre spacing.
- Oppdaterer sidepanelet til samme kortstil for å skape en helhetlig opplevelse.
- Legger til gjenbrukbare farger og radius-konstanter for kort og paneler.

## Testing
- pytest *(feilet fordi pandas og openpyxl mangler i miljøet)*

------
https://chatgpt.com/codex/tasks/task_e_68ff8749b37483289bdd41c0713a3900