### PR TITLE
Migrer GUI til PyQt

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -10,9 +10,8 @@ import sys
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-import pandas as pd
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 from data_utils import (
@@ -37,7 +36,10 @@ from .busy import hide_busy, show_busy, start_worker
 from .ledger import populate_ledger_table
 from .mainview import MainView
 from .sidebar import SidebarWidget
-from .style import apply_palette, style
+from .style import apply_palette, apply_stylesheet, style
+
+if TYPE_CHECKING:  # pragma: no cover - kun for typehinting
+    import pandas as pd
 
 APP_TITLE = "Bilagskontroll"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
@@ -110,6 +112,7 @@ class App(QtWidgets.QMainWindow):
             self._owns_qt_app = True
         super().__init__()
         self.setWindowTitle(APP_TITLE)
+        self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
 
         self._workers: list[QtCore.QThread] = []
         self._progress_timer: Optional[QtCore.QTimer] = None
@@ -153,12 +156,20 @@ class App(QtWidgets.QMainWindow):
         self._init_geometry()
         self._build_ui()
         self._init_shortcuts()
-        self.render()
+        QtCore.QTimer.singleShot(0, self._after_init)
 
     # Init
     def _init_theme(self, default: str) -> None:
         style.set_theme(default.lower())
         apply_palette(self._qt_app)
+        apply_stylesheet(self._qt_app)
+
+    def _after_init(self) -> None:
+        self.render()
+        if hasattr(self.sidebar, "refresh_theme"):
+            self.sidebar.refresh_theme()
+        if hasattr(self.main_view, "refresh_theme"):
+            self.main_view.refresh_theme()
 
     def _init_geometry(self) -> None:
         screen = QtWidgets.QDesktopWidget().availableGeometry(self)
@@ -624,6 +635,7 @@ class App(QtWidgets.QMainWindow):
         mode = (mode or "").strip()
         style.set_theme(mode.lower())
         apply_palette(self._qt_app)
+        apply_stylesheet(self._qt_app)
         if hasattr(self.theme_menu, "blockSignals"):
             self.theme_menu.blockSignals(True)
             idx = 0 if mode.lower() != "dark" else 1
@@ -631,6 +643,8 @@ class App(QtWidgets.QMainWindow):
             self.theme_menu.blockSignals(False)
         if hasattr(self.sidebar, "refresh_theme"):
             self.sidebar.refresh_theme()
+        if hasattr(self.main_view, "refresh_theme"):
+            self.main_view.refresh_theme()
         if hasattr(self, "ledger_table") and hasattr(self.ledger_table, "refresh_theme"):
             self.ledger_table.refresh_theme()
         self.render()

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,40 +1,43 @@
 # -*- coding: utf-8 -*-
-"""GUI-moduler for Bilagskontroll."""
+"""PyQt-basert GUI for Bilagskontroll."""
+
+from __future__ import annotations
 
 import json
 import os
 import re
-
+import sys
+from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
+from typing import Any, Optional
 
-from .style import style
-from helpers import logger
-from tkinter import TclError
+import pandas as pd
+from PyQt5 import QtCore, QtGui, QtWidgets
 
-try:
-    from settings import UI_SCALING
-except Exception as e:  # pragma: no cover - valfri innstilling
-    logger.warning(f"UI_SCALING kunne ikke lastes: {e}")
-    UI_SCALING = None
-
-# CustomTkinter importeres ved behov for raskere oppstart.
-_ctk_mod = None
-
-# Standard tema som brukes dersom brukeren ikke velger noe annet.
-DEFAULT_APPEARANCE_MODE = "light"
-
-
-def _ctk():
-    """Importer ``customtkinter`` ved første kall og returner modulen."""
-    global _ctk_mod
-    if _ctk_mod is None:
-        import customtkinter as ctk
-
-        _ctk_mod = ctk
-    return _ctk_mod
-
-# Tkinter og CustomTkinter importeres lazily for raskere oppstart.
+from data_utils import (
+    _net_amount_from_row,
+    calc_sum_kontrollert,
+    calc_sum_net_all,
+    load_gl_df,
+    load_invoice_df,
+)
+from helpers import (
+    fmt_money,
+    fmt_pct,
+    format_number_with_thousands,
+    guess_col,
+    guess_invoice_col,
+    guess_net_amount_col,
+    logger,
+    only_digits,
+    to_str,
+)
+from .busy import hide_busy, show_busy, start_worker
+from .ledger import populate_ledger_table
+from .mainview import MainView
+from .sidebar import SidebarWidget
+from .style import apply_palette, style
 
 APP_TITLE = "Bilagskontroll"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
@@ -48,82 +51,83 @@ else:
 
 WINDOW_CONFIG_FILE = _CONFIG_DIR / "settings.json"
 
-# For bakoverkompatibilitet
-get_color = style.get_color
+
+@dataclass
+class SimpleVar:
+    value: str = ""
+
+    def get(self) -> str:
+        return self.value
+
+    def set(self, value: str) -> None:
+        self.value = value
 
 
-def create_button(master, **kwargs):
-    """Opprett en knapp med felles stil."""
-    ctk = _ctk()
+def _set_text(widget: Any, text: str) -> None:
+    if hasattr(widget, "configure"):
+        widget.configure(text=text)
+    elif hasattr(widget, "setText"):
+        widget.setText(text)
 
-    options = {
-        "fg_color": style.BTN_FG,
-        "hover_color": style.BTN_HOVER,
-        "font": style.FONT_BODY,
-        "corner_radius": style.BTN_RADIUS,
-    }
-    options.update(kwargs)
-    return ctk.CTkButton(master, **options)
 
-# ----------------- App -----------------
-class App:
+def _set_enabled(widget: Any, enabled: bool) -> None:
+    if hasattr(widget, "configure"):
+        widget.configure(state="normal" if enabled else "disabled")
+    elif hasattr(widget, "setEnabled"):
+        widget.setEnabled(enabled)
+
+
+def _clear_text(widget: Any) -> None:
+    if hasattr(widget, "delete"):
+        widget.delete("0.0", "end")
+    elif hasattr(widget, "clear"):
+        widget.clear()
+
+
+def _insert_text(widget: Any, text: str) -> None:
+    if hasattr(widget, "insert"):
+        widget.insert("0.0", text)
+    elif hasattr(widget, "setPlainText"):
+        widget.setPlainText(text)
+
+
+def _get_text(widget: Any) -> str:
+    if hasattr(widget, "get"):
+        return widget.get("0.0", "end") if callable(widget.get) else str(widget.get)
+    if hasattr(widget, "toPlainText"):
+        return widget.toPlainText()
+    if hasattr(widget, "text"):
+        return widget.text()
+    return ""
+
+
+class App(QtWidgets.QMainWindow):
     def __init__(self):
-        import tkinter as tk
-        ctk = _ctk()
+        self._qt_app = QtWidgets.QApplication.instance()
+        self._owns_qt_app = False
+        if self._qt_app is None:
+            self._qt_app = QtWidgets.QApplication(sys.argv or ["Bilagskontroll"])
+            self._owns_qt_app = True
+        super().__init__()
+        self.setWindowTitle(APP_TITLE)
 
-        globals().update(tk=tk, ctk=ctk)
+        self._workers: list[QtCore.QThread] = []
+        self._progress_timer: Optional[QtCore.QTimer] = None
+        self._progress_running = False
+        self._progress_msg = ""
+        self._progress_val = 0
+        self._pdf_prompt_shown = False
+        self._busy_dialog: Optional[QtWidgets.QDialog] = None
 
-        # Endre klassen dynamisk slik at den arver fra ``CTk``.
-        cls = self.__class__
-        self.__class__ = type(cls.__name__, (ctk.CTk, cls), {})
-        ctk.CTk.__init__(self)
-
-        # Hjelpefunksjoner fra helpers importeres først ved behov for å
-        # unngå unødvendig overhead ved oppstart.
-        self._helpers_loaded = False
-
-        self._dnd_ready = False
-        self._icon_ready = False
-        self.title(APP_TITLE)
-
-        screen_w = self.winfo_screenwidth()
-        screen_h = self.winfo_screenheight()
-        origin_x = 0
-        origin_y = 0
-        if os.name == "nt":
-            import ctypes
-
-            work_area = ctypes.wintypes.RECT()
-            SPI_GETWORKAREA = 0x0030
-            if ctypes.windll.user32.SystemParametersInfoW(
-                SPI_GETWORKAREA, 0, ctypes.byref(work_area), 0
-            ):
-                screen_w = work_area.right - work_area.left
-                screen_h = work_area.bottom - work_area.top
-                origin_x = work_area.left
-                origin_y = work_area.top
-        width = min(int(screen_w * 0.8), MAX_APP_WIDTH)
-        height = int(screen_h * 0.9)
-        min_w = min(int(screen_w * 0.6), MIN_APP_WIDTH)
-        min_h = int(screen_h * 0.7)
-        width, height = self._load_window_size(width, height, min_w, min_h, screen_w, screen_h)
-        x = origin_x + max((screen_w - width) // 2, 0)
-        y = origin_y + max((screen_h - height) // 2, 0)
-        self.geometry(f"{width}x{height}+{x}+{y}")
-        self.minsize(min_w, min_h)
-
-        self.app_icon_img = None
-
-        self.df = None
-        self.sample_df = None
-        self.decisions, self.comments = [], []
+        self.df: Optional[pd.DataFrame] = None
+        self.sample_df: Optional[pd.DataFrame] = None
+        self.gl_df: Optional[pd.DataFrame] = None
+        self.gl_index: dict[str, Any] = {}
+        self.decisions: list[Optional[str]] = []
+        self.comments: list[str] = []
         self.idx = 0
-        self.invoice_col = None
-        self.net_amount_col = None
-        self.antall_bilag = 0
-
-        # GL
-        self.gl_df = None
+        self.invoice_col: Optional[str] = None
+        self.net_amount_col: Optional[str] = None
         self.gl_invoice_col = None
         self.gl_accountno_col = None
         self.gl_accountname_col = None
@@ -135,281 +139,62 @@ class App:
         self.gl_credit_col = None
         self.gl_amount_col = None
         self.gl_postedby_col = None
+        self.antall_bilag = 0
 
-        # Framdriftsindikator
-        self._progress_job = None
-        self._progress_running = False
-        self._progress_val = 0
-        self._progress_msg = ""
-        self._pdf_prompt_shown = False
+        default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+        self.file_path_var = SimpleVar()
+        self.gl_path_var = SimpleVar()
+        self.sample_size_var = SimpleVar()
+        self.year_var = SimpleVar()
+        self.kunde_var = SimpleVar()
+        self.utfort_av_var = SimpleVar(default_user)
 
-        self.logo_img = None
-        self._theme_initialized = False
-        self.after_idle(self._build_ui)
-
-    def _init_fonts(self):
-        ctk = _ctk()
-        s = style
-        kwargs = {"family": s.FONT_FAMILY}
-        if s.FONT_TITLE is None:
-            s.FONT_TITLE = ctk.CTkFont(size=16, weight="bold", **kwargs)
-        if s.FONT_BODY is None:
-            s.FONT_BODY = ctk.CTkFont(size=14, **kwargs)
-        if s.FONT_TITLE_LITE is None:
-            s.FONT_TITLE_LITE = ctk.CTkFont(size=16, **kwargs)
-        if s.FONT_TITLE_LARGE is None:
-            s.FONT_TITLE_LARGE = ctk.CTkFont(size=18, weight="bold", **kwargs)
-        if s.FONT_TITLE_SMALL is None:
-            s.FONT_TITLE_SMALL = ctk.CTkFont(size=15, weight="bold", **kwargs)
-        if s.FONT_BODY_BOLD is None:
-            s.FONT_BODY_BOLD = ctk.CTkFont(size=14, weight="bold", **kwargs)
-        if s.FONT_SMALL is None:
-            s.FONT_SMALL = ctk.CTkFont(size=13, **kwargs)
-        if s.FONT_SMALL_ITALIC is None:
-            s.FONT_SMALL_ITALIC = ctk.CTkFont(size=12, slant="italic", **kwargs)
-
-    def _ensure_helpers(self):
-        """Importer tunge hjelpefunksjoner fra ``helpers`` ved første behov."""
-        if getattr(self, "_helpers_loaded", False):
-            return
-        from helpers import (
-            to_str,
-            fmt_money,
-            format_number_with_thousands,
-            guess_invoice_col,
-            guess_col,
-            guess_net_amount_col,
-            fmt_pct,
-            logger,
-        )
-        globals().update(
-            to_str=to_str,
-            fmt_money=fmt_money,
-            format_number_with_thousands=format_number_with_thousands,
-            guess_invoice_col=guess_invoice_col,
-            guess_col=guess_col,
-            guess_net_amount_col=guess_net_amount_col,
-            fmt_pct=fmt_pct,
-            logger=logger,
-        )
-        self._helpers_loaded = True
-
-    def _build_ui(self):
-        """Startar eit minimums-UI og utset tunge delar."""
-        self._init_fonts()
-        self._init_ui()
-        self.after(0, self._build_sidebar)
-        self.after(0, self._build_main)
-        self.after_idle(self._post_init)
-
-    def _init_ui(self):
-        try:
-            from tkinterdnd2 import TkinterDnD
-        except ImportError as e:
-            logger.warning(f"tkinterdnd2 ikke tilgjengelig: {e}")
-            TkinterDnD = None
-
-        self._TkinterDnD = TkinterDnD
-
-        self.grid_columnconfigure(0, weight=0)
-        self.grid_columnconfigure(1, weight=1)
-        self.grid_rowconfigure(0, weight=1)
-
-        self.bind("<Left>", lambda e: self.prev())
-        self.bind("<Right>", lambda e: self.next())
-        self.bind("<Control-o>", lambda e: self.open_in_po())
-
-        self.protocol("WM_DELETE_WINDOW", self.destroy)
-
-    def _build_sidebar(self):
-        from .sidebar import build_sidebar
-
-        self.sidebar = build_sidebar(self)
-        self.sample_size_var.set("")
-        self.year_var.set("")
-
-    def _build_main(self):
-        from .mainview import build_main
-
-        self.main = build_main(self)
-        if self.gl_df is not None:
-            self.after(0, self._build_ledger_widgets)
+        self._init_theme("Light")
+        self._init_geometry()
+        self._build_ui()
+        self._init_shortcuts()
         self.render()
 
-    def _build_ledger_widgets(self):
-        from .mainview import build_ledger_widgets
+    # Init
+    def _init_theme(self, default: str) -> None:
+        style.set_theme(default.lower())
+        apply_palette(self._qt_app)
 
-        build_ledger_widgets(self)
+    def _init_geometry(self) -> None:
+        screen = QtWidgets.QDesktopWidget().availableGeometry(self)
+        width = min(int(screen.width() * 0.8), MAX_APP_WIDTH)
+        height = int(screen.height() * 0.9)
+        min_w = min(int(screen.width() * 0.6), MIN_APP_WIDTH)
+        min_h = int(screen.height() * 0.7)
+        saved = self._load_window_size(width, height, min_w, min_h, screen.width(), screen.height())
+        self.resize(*saved)
+        self.setMinimumSize(min_w, min_h)
+        self.move(screen.center() - self.rect().center())
 
-    def _post_init(self):
-        self.after(200, self._init_theme)
-        self.after(200, self.load_logo_images)
-        self._init_dnd()
-        self.after(200, self._init_icon)
+    def _build_ui(self) -> None:
+        central = QtWidgets.QWidget(self)
+        layout = QtWidgets.QHBoxLayout(central)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self.setCentralWidget(central)
 
-    def _init_dnd(self):
-        TkinterDnD = getattr(self, "_TkinterDnD", None)
-        if not TkinterDnD:
-            return
+        self.sidebar = SidebarWidget(self)
+        layout.addWidget(self.sidebar)
 
-        self.__class__ = type(
-            self.__class__.__name__, (self.__class__, TkinterDnD.DnDWrapper), {}
-        )
-        TkinterDnD.DnDWrapper.__init__(self)
-        TkinterDnD._require(self)
-        self._dnd = TkinterDnD
-        self.drop_target_register("DND_Files")
-        self.dnd_bind("<<Drop>>", self._on_drop)
-        self._dnd_ready = True
+        self.main_view = MainView(self)
+        layout.addWidget(self.main_view, 1)
 
-    def add_drop_target(self, widget, func):
-        """Registrer eit widget som mål for dra-og-slipp."""
+    def _init_shortcuts(self) -> None:
+        QtWidgets.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_Left), self, self.prev)
+        QtWidgets.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_Right), self, self.next)
+        QtWidgets.QShortcut(QtGui.QKeySequence("Ctrl+O"), self, self.open_in_po)
 
-        def _register():
-            if getattr(self, "_dnd_ready", False):
-                try:
-                    widget.drop_target_register("DND_Files")
-                    widget.dnd_bind("<<Drop>>", func)
-                except TclError as e:
-                    logger.debug(f"DnD-registrering feilet: {e}")
-            else:
-                self.after(200, _register)
-
-        _register()
-
-    def _init_icon(self):
-        self._update_icon()
-        self._icon_ready = True
-
-    # Theme
-    def _init_theme(self):
-        ctk = _ctk()
-        if getattr(self, "_theme_initialized", False):
-            return
-        ctk.set_appearance_mode(DEFAULT_APPEARANCE_MODE)
-        ctk.set_default_color_theme("blue")
-        scale = UI_SCALING or (self.winfo_fpixels("1i") / 96)
-        if hasattr(ctk, "set_widget_scaling"):
-            ctk.set_widget_scaling(scale)
-        elif hasattr(ctk, "set_scaling"):
-            ctk.set_scaling(scale)
-        if hasattr(ctk, "set_spacing_scaling"):
-            ctk.set_spacing_scaling(scale)
-        elif hasattr(ctk, "set_window_scaling"):
-            ctk.set_window_scaling(scale)
-        self._theme_initialized = True
-
-    def _switch_theme(self, mode):
-        ctk = _ctk()
-        self._init_theme()
-        mode = str(mode).strip().lower()
-        if mode not in {"light", "dark"}:
-            mode = DEFAULT_APPEARANCE_MODE
-        ctk.set_appearance_mode(mode)
-        if hasattr(self, "theme_var"):
-            self.theme_var.set(mode.title())
-        if self._icon_ready:
-            self._update_icon()
-        from .ledger import apply_treeview_theme, update_treeview_stripes
-
-        apply_treeview_theme(self)
-        update_treeview_stripes(self)
-        self.render()
-
-    def _update_icon(self):
-        ctk = _ctk()
-        from helpers_path import resource_path
-        try:
-            ctk.get_appearance_mode()
-        except (AttributeError, TclError) as e:
-            logger.debug(f"Klarte ikke hente tema: {e}")
-        ico = "icons/bilagskontroll_logo_all.ico"
-        ico_path = resource_path(ico)
-        try:
-            self.iconbitmap(ico_path)
-        except (TclError, OSError) as e:
-            logger.debug(f"Kunne ikke sette ikon: {e}")
-        try:
-            from PIL import Image, ImageTk
-
-            with Image.open(ico_path) as icon_img:
-                icon_rgba = icon_img.convert("RGBA")
-                self.app_icon_img = ImageTk.PhotoImage(icon_rgba)
-            self.iconphoto(False, self.app_icon_img)
-        except ImportError as e:
-            logger.debug(f"Kunne ikke importere PIL for ikon: {e}")
-        except (TclError, OSError) as e:
-            logger.debug(f"Kunne ikke laste ikonbilde: {e}")
-        except Exception as e:  # pragma: no cover - uventa PIL-feil
-            logger.debug(f"Kunne ikke konvertere ikon: {e}")
-
-    def load_logo_images(self):
-        ctk = _ctk()
-        from helpers_path import resource_path
-        try:
-            from PIL import Image
-            img = Image.open(resource_path("icons/bilagskontroll_logo_all.ico"))
-            try:
-                self.logo_img = ctk.CTkImage(light_image=img, size=(32, 32))
-            except TypeError:
-                self.logo_img = ctk.CTkImage(img, size=(32, 32))
-        except (ImportError, OSError) as e:
-            logger.error(f"Kunne ikke laste logo: {e}")
-            self.logo_img = None
-            return
-
-    def _on_drop(self, event):
-        path = event.data.strip("{}").strip()
-        if not path.lower().endswith((".xlsx", ".xls")):
-            return
-        if "hovedbok" in os.path.basename(path).lower():
-            self.gl_path_var.set(path)
-            self._load_gl_excel()
-        else:
-            self.file_path_var.set(path)
-            self._load_excel()
-
-    # Files
-    def choose_file(self):
-        from tkinter import filedialog
-        p = filedialog.askopenfilename(title="Velg Excel (fakturaliste)", filetypes=[("Excel","*.xlsx *.xls")])
-        if not p: return
-        self.file_path_var.set(p)
-        self._load_excel()
-
-    def choose_gl_file(self):
-        from tkinter import filedialog
-        p = filedialog.askopenfilename(title="Velg Hovedbok (Excel)", filetypes=[("Excel","*.xlsx *.xls")])
-        if not p: return
-        self.gl_path_var.set(p)
-        self._load_gl_excel()
-
-    def destroy(self):
-        ctk = _ctk()
-        self._save_window_size()
-        try:
-            if hasattr(self, "ledger_tree") and hasattr(self, "_ledger_configure_id"):
-                self.ledger_tree.unbind("<Configure>", self._ledger_configure_id)
-        except TclError as e:
-            logger.debug(f"Kunne ikke unbinde ledger: {e}")
-        try:
-            ctk.ScalingTracker.remove_window(self.destroy, self)
-        except ValueError as e:
-            logger.debug(f"ScalingTracker.remove_window feilet: {e}")
-        if self._dnd_ready:
-            try:
-                self._dnd.Tk.destroy(self)
-            except TclError as e:
-                logger.debug(f"DnD-destroy feilet: {e}")
-
+    # Konfig lagring
     def _load_window_size(self, width, height, min_w, min_h, screen_w, screen_h):
         try:
             with WINDOW_CONFIG_FILE.open("r", encoding="utf-8") as fh:
                 data = json.load(fh)
-        except FileNotFoundError:
-            return width, height
-        except (OSError, json.JSONDecodeError) as e:
-            logger.debug(f"Kunne ikke lese vindustørrelse: {e}")
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
             return width, height
 
         win_cfg = data.get("window", {}) if isinstance(data, dict) else {}
@@ -423,49 +208,171 @@ class App:
         saved_h = max(min(saved_h, screen_h), min_h)
         return saved_w or width, saved_h or height
 
-    def _save_window_size(self):
-        try:
-            self.update_idletasks()
-            width = int(self.winfo_width())
-            height = int(self.winfo_height())
-        except (TclError, ValueError) as e:
-            logger.debug(f"Kunne ikke hente vindustørrelse: {e}")
-            return
-
-        if width <= 1 or height <= 1:
-            return
-
-        try:
-            with WINDOW_CONFIG_FILE.open("r", encoding="utf-8") as fh:
-                loaded = json.load(fh)
-                data = loaded if isinstance(loaded, dict) else {}
-        except FileNotFoundError:
-            data = {}
-        except (OSError, json.JSONDecodeError) as e:
-            logger.debug(f"Kunne ikke lese eksisterende innstillinger: {e}")
-            data = {}
-
-        data["window"] = {"width": width, "height": height}
-
+    def _save_window_size(self) -> None:
         try:
             WINDOW_CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+            data = {}
+            if WINDOW_CONFIG_FILE.exists():
+                with WINDOW_CONFIG_FILE.open("r", encoding="utf-8") as fh:
+                    loaded = json.load(fh)
+                    data = loaded if isinstance(loaded, dict) else {}
+            data["window"] = {"width": self.width(), "height": self.height()}
             with WINDOW_CONFIG_FILE.open("w", encoding="utf-8") as fh:
                 json.dump(data, fh)
-        except OSError as e:
-            logger.debug(f"Kunne ikke lagre vindustørrelse: {e}")
+        except OSError:
+            logger.debug("Kunne ikke lagre vindusstørrelse")
 
-    # Read
+    # Qt hooks
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # noqa: D401
+        self._save_window_size()
+        super().closeEvent(event)
+
+    # Offentlige APIer
+    def mainloop(self):
+        self.show()
+        if self._owns_qt_app:
+            self._qt_app.exec_()
+
+    # Filhåndtering
+    def choose_file(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Velg Excel (fakturaliste)", "", "Excel (*.xlsx *.xls)"
+        )
+        if path:
+            self.file_path_var.set(path)
+            self.sidebar.update_invoice_path(path)
+            self._load_excel()
+
+    def choose_gl_file(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Velg Hovedbok (Excel)", "", "Excel (*.xlsx *.xls)"
+        )
+        if path:
+            self.gl_path_var.set(path)
+            self.sidebar.update_gl_path(path)
+            self._load_gl_excel()
+
+    def _load_excel(self):
+        path = self.file_path_var.get()
+        if not path:
+            return
+        self._start_progress("Laster fakturaliste...")
+        self._busy_dialog = show_busy(self, "Laster fakturaliste...")
+
+        def worker():
+            df, cust = load_invoice_df(path, header_idx=4)
+            invoice_col = guess_invoice_col(df.columns)
+            net_amount_col = guess_net_amount_col(df.columns)
+            try:
+                df["_netto_float"] = df.apply(_net_amount_from_row, axis=1, args=(net_amount_col,))
+            except (TypeError, ValueError):
+                logger.exception("Kunne ikke beregne nettobeløp")
+                df["_netto_float"] = None
+            antall = len(df.dropna(how="all"))
+            return df, cust, invoice_col, net_amount_col, antall
+
+        def on_success(result):
+            df, cust, invoice_col, net_amount_col, antall = result
+            self.df = df
+            self.sample_df = None
+            self.decisions = []
+            self.comments = []
+            self.idx = 0
+            self.antall_bilag = antall
+            self.invoice_col = invoice_col
+            self.net_amount_col = net_amount_col
+            if cust:
+                self.kunde_var.set(cust)
+                self.sidebar.kunde_edit.setText(cust)
+            self._update_counts_labels()
+            self.render()
+            self._update_year_options()
+            self._finish_progress()
+            hide_busy(self)
+
+        def on_error(exc: Exception):
+            hide_busy(self)
+            self._finish_progress()
+            QtWidgets.QMessageBox.critical(self, APP_TITLE, f"Klarte ikke lese Excel:\n{exc}")
+
+        worker_thread = start_worker(worker, on_success=on_success, on_error=on_error)
+        self._workers.append(worker_thread)
+
+        def _cleanup():
+            try:
+                self._workers.remove(worker_thread)
+            except ValueError:
+                pass
+
+        worker_thread.finished.connect(_cleanup)
+
+    def _load_gl_excel(self):
+        path = self.gl_path_var.get()
+        if not path:
+            return
+        self._start_progress("Laster hovedbok...")
+        self._busy_dialog = show_busy(self, "Laster hovedbok...")
+
+        def worker():
+            gl = load_gl_df(path, nrows=10)
+            return gl
+
+        def on_success(gl: pd.DataFrame):
+            if gl is None or gl.dropna(how="all").empty:
+                QtWidgets.QMessageBox.warning(self, APP_TITLE, "Hovedboken ser tom ut.")
+            else:
+                self.gl_df = gl
+                cols = [str(c) for c in gl.columns]
+                self.gl_invoice_col = guess_invoice_col(cols)
+                self.gl_accountno_col = guess_col(cols, r"^kontonr\.?$", r"konto.*nummer", r"account.*(number|no)", r"acct.*no")
+                self.gl_accountname_col = guess_col(cols, r"^kontonavn$", r"konto\s*navn", r"^konto$", r"account.*name", r"(?:^| )navn$")
+                self.gl_text_col = guess_col(cols, r"^tekst$", r"text", r"posteringstekst")
+                self.gl_desc_col = guess_col(cols, r"beskrivelse", r"description", r"forklaring")
+                self.gl_vatcode_col = guess_col(cols, r"^mva(?!-)|mva[- ]?kode", r"^vat(?!.*amount)|tax code")
+                self.gl_vatamount_col = guess_col(cols, r"mva[- ]?bel(ø|o)p", r"vat amount", r"tax amount")
+                self.gl_debit_col = guess_col(cols, r"^debet$", r"debit")
+                self.gl_credit_col = guess_col(cols, r"^kredit$", r"credit")
+                self.gl_amount_col = guess_col(cols, r"^bel(ø|o)p$", r"amount", r"sum")
+                self.gl_postedby_col = guess_col(cols, r"postert\s*av", r"bokf(ø|o)rt\s*av", r"registrert\s*av", r"posted\s*by", r"created\s*by")
+                if self.gl_invoice_col in self.gl_df.columns:
+                    self.gl_df["_inv_norm"] = self.gl_df[self.gl_invoice_col].map(only_digits)
+                else:
+                    self.gl_df["_inv_norm"] = ""
+                self.gl_index = self.gl_df.groupby("_inv_norm").indices
+                if self.sample_df is not None:
+                    self.render()
+                self._update_year_options()
+            self._finish_progress()
+            hide_busy(self)
+
+        def on_error(exc: Exception):
+            hide_busy(self)
+            self._finish_progress()
+            QtWidgets.QMessageBox.critical(self, APP_TITLE, f"Klarte ikke lese hovedbok:\n{exc}")
+
+        worker_thread = start_worker(worker, on_success=on_success, on_error=on_error)
+        self._workers.append(worker_thread)
+
+        def _cleanup_gl():
+            try:
+                self._workers.remove(worker_thread)
+            except ValueError:
+                pass
+
+        worker_thread.finished.connect(_cleanup_gl)
+
+    # Årsliste
     def _update_year_options(self):
         from datetime import datetime
+
         years: set[int] = set()
-        for df in (getattr(self, "df", None), getattr(self, "gl_df", None)):
+        for df in (self.df, self.gl_df):
             if df is None or "Fakturadato" not in df.columns:
                 continue
             for val in df["Fakturadato"].dropna().astype(str):
                 m = re.search(r"(19|20)\d{2}", val)
                 if m:
                     years.add(int(m.group(0)))
-
         now = datetime.now().year
         if years:
             filtered = sorted([y for y in years if y >= now - 1], reverse=True)
@@ -474,182 +381,37 @@ class App:
             values = [str(y) for y in filtered]
         else:
             values = [str(now), str(now - 1)]
+        self.sidebar.set_year_options(values)
+        if values:
+            self.year_var.set(values[0])
 
-        if hasattr(self, "year_combo"):
-            self.year_combo.configure(values=values)
-        if getattr(self, "year_var", None) and self.year_var.get() not in values:
-            self.year_var.set(values[0] if values else "")
-        from .sidebar import _toggle_sample_btn
-        _toggle_sample_btn(self)
-
-    def _load_excel(self):
-        from tkinter import messagebox
-
-        self._ensure_helpers()
-        from data_utils import load_invoice_df, _net_amount_from_row
-        from .busy import show_busy, hide_busy, run_in_thread
-
-        path = self.file_path_var.get()
-        if not path:
-            return
-        logger.info(f"Laster fakturaliste fra {path}")
-        header_idx = 4
-        big = os.path.getsize(path) > 5 * 1024 * 1024
-        if big and hasattr(self, "inline_status"):
-            self.inline_status.configure(text="laster inn fil...")
-            self.inline_status.update_idletasks()
-        show_busy(self, "Laster fakturaliste...")
-
-        def finalize():
-            if big and hasattr(self, "inline_status"):
-                self.inline_status.configure(text="")
-            self._finish_progress()
-            hide_busy(self)
-
-        def worker():
-            self.after(0, lambda: self._start_progress("Laster fakturaliste..."))
-            try:
-                df, cust = load_invoice_df(path, header_idx)
-            except (OSError, ValueError) as e:
-                logger.error(f"Klarte ikke lese Excel: {e}")
-                self.after(0, lambda: (messagebox.showerror(APP_TITLE, f"Klarte ikke lese Excel:\n{e}"), finalize()))
-                return
-
-            def success():
-                self.antall_bilag = len(df.dropna(how="all"))
-                self.df = df
-                if cust:
-                    self.kunde_var.set(cust)
-                    if hasattr(self, "kunde_entry"):
-                        self.kunde_entry.configure(state="disabled")
-                if self.df is None or self.df.dropna(how="all").empty:
-                    messagebox.showwarning(APP_TITLE, "Excel-filen ser tom ut.")
-                    finalize()
-                    return
-                self.invoice_col = guess_invoice_col(self.df.columns)
-                self.net_amount_col = guess_net_amount_col(self.df.columns)
-                try:
-                    self.df["_netto_float"] = self.df.apply(
-                        _net_amount_from_row, axis=1, args=(self.net_amount_col,)
-                    )
-                except (TypeError, ValueError):
-                    logger.exception("Kunne ikke beregne nettobeløp")
-                    self.df["_netto_float"] = None
-                self.sample_df = None; self.decisions=[]; self.comments=[]; self.idx=0
-                self._update_counts_labels()
-                self.render()
-                self._update_year_options()
-                finalize()
-
-            self.after(0, success)
-
-        run_in_thread(worker)
-
-    def _load_gl_excel(self):
-        from tkinter import messagebox
-
-        self._ensure_helpers()
-        from data_utils import load_gl_df
-        from .busy import show_busy, hide_busy, run_in_thread
-
-        path = self.gl_path_var.get()
-        if not path:
-            return
-        logger.info(f"Laster hovedbok fra {path}")
-        big = os.path.getsize(path) > 5 * 1024 * 1024
-        if big and hasattr(self, "inline_status"):
-            self.inline_status.configure(text="laster inn fil...")
-            self.inline_status.update_idletasks()
-        show_busy(self, "Laster hovedbok...")
-
-        def finalize():
-            if big and hasattr(self, "inline_status"):
-                self.inline_status.configure(text="")
-            self._finish_progress()
-            hide_busy(self)
-
-        def worker():
-            self.after(0, lambda: self._start_progress("Laster hovedbok..."))
-            try:
-                gl = load_gl_df(path, nrows=10)
-            except (OSError, ValueError) as e:
-                logger.error(f"Klarte ikke lese hovedbok: {e}")
-                self.after(0, lambda: (messagebox.showerror(APP_TITLE, f"Klarte ikke lese hovedbok:\n{e}"), finalize()))
-                return
-
-            def success():
-                if gl is None or gl.dropna(how="all").empty:
-                    messagebox.showwarning(APP_TITLE, "Hovedboken ser tom ut.")
-                    finalize()
-                    return
-
-                self.gl_df = gl
-                cols = [str(c) for c in gl.columns]
-                self.gl_invoice_col     = guess_invoice_col(cols)
-                self.gl_accountno_col   = guess_col(cols, r"^kontonr\.?$", r"konto.*nummer", r"account.*(number|no)", r"acct.*no")
-                self.gl_accountname_col = guess_col(cols, r"^kontonavn$", r"konto\s*navn", r"^konto$", r"account.*name", r"(?:^| )navn$")
-                self.gl_text_col        = guess_col(cols, r"^tekst$", r"text", r"posteringstekst")
-                self.gl_desc_col        = guess_col(cols, r"beskrivelse", r"description", r"forklaring")
-                self.gl_vatcode_col     = guess_col(cols, r"^mva(?!-)|mva[- ]?kode", r"^vat(?!.*amount)|tax code")
-                self.gl_vatamount_col   = guess_col(cols, r"mva[- ]?bel(ø|o)p", r"vat amount", r"tax amount")
-                self.gl_debit_col       = guess_col(cols, r"^debet$", r"debit")
-                self.gl_credit_col      = guess_col(cols, r"^kredit$", r"credit")
-                self.gl_amount_col      = guess_col(cols, r"^bel(ø|o)p$", r"amount", r"sum")
-                self.gl_postedby_col    = guess_col(cols, r"postert\s*av", r"bokf(ø|o)rt\s*av", r"registrert\s*av", r"posted\s*by", r"created\s*by")
-
-                from helpers import only_digits
-                if self.gl_invoice_col in self.gl_df.columns:
-                    self.gl_df["_inv_norm"] = self.gl_df[self.gl_invoice_col].map(only_digits)
-                else:
-                    self.gl_df["_inv_norm"] = ""
-                self.gl_index = self.gl_df.groupby("_inv_norm").indices
-
-                from .ledger import populate_ledger_table
-                from .mainview import build_ledger_widgets
-                self.populate_ledger_table = populate_ledger_table
-
-                if not hasattr(self, "ledger_tree"):
-                    build_ledger_widgets(self)
-
-                if self.sample_df is not None:
-                    self.render()
-                self._update_year_options()
-                finalize()
-
-            self.after(0, success)
-
-        run_in_thread(worker)
-# Sampling / nav
+    # Utvalg
     def _update_counts_labels(self):
-        self.lbl_filecount.configure(text=f"Antall bilag: {self.antall_bilag}")
-        
+        if hasattr(self, "lbl_filecount"):
+            _set_text(self.lbl_filecount, f"Antall bilag: {self.antall_bilag}")
+
     def make_sample(self):
-        from tkinter import messagebox
-        self._ensure_helpers()
         if self.df is None:
-            messagebox.showinfo(APP_TITLE, "Velg Excel først."); return
+            QtWidgets.QMessageBox.information(self, APP_TITLE, "Velg Excel først.")
+            return
         try:
             n = int(self.sample_size_var.get())
             year = int(self.year_var.get())
         except ValueError:
-            messagebox.showinfo(APP_TITLE, "Oppgi antall og år.")
+            QtWidgets.QMessageBox.information(self, APP_TITLE, "Oppgi antall og år.")
             return
         n = max(1, min(n, len(self.df)))
-        logger.info(f"Trekker utvalg på {n} bilag for år {year}")
         try:
-            self.sample_df = (
-                self.df.sample(n=n, random_state=year)
-                .reset_index(drop=True)
-                .copy()
-            )
-        except ValueError as e:
-            logger.error(f"Feil ved trekking av utvalg: {e}")
-            messagebox.showerror(APP_TITLE, f"Feil ved trekking av utvalg:\n{e}"); return
-        self.decisions = [None]*len(self.sample_df); self.comments=[""]*len(self.sample_df); self.idx=0
+            self.sample_df = self.df.sample(n=n, random_state=year).reset_index(drop=True).copy()
+        except ValueError as exc:
+            QtWidgets.QMessageBox.critical(self, APP_TITLE, f"Feil ved trekking av utvalg:\n{exc}")
+            return
+        self.decisions = [None] * len(self.sample_df)
+        self.comments = [""] * len(self.sample_df)
+        self.idx = 0
         self.render()
 
     def _current_row_dict(self):
-        self._ensure_helpers()
         row = self.sample_df.iloc[self.idx]
         return {
             str(c): to_str(row[c])
@@ -657,166 +419,145 @@ class App:
             if not str(c).startswith("_")
         }
 
-    def set_decision_and_next(self, val, advance=True):
-        if self.sample_df is None: return
-        self.comments[self.idx] = self.comment_box.get("0.0", "end").strip()
+    def set_decision_and_next(self, val: str, advance: bool = True):
+        if self.sample_df is None:
+            return
+        self.comments[self.idx] = _get_text(self.comment_box).strip()
         self.decisions[self.idx] = val
         if advance and self.idx < len(self.sample_df) - 1:
             self.idx += 1
         self.render()
 
     def prev(self):
-        if self.sample_df is None: return
-        self.comments[self.idx] = self.comment_box.get("0.0", "end").strip()
+        if self.sample_df is None:
+            return
+        self.comments[self.idx] = _get_text(self.comment_box).strip()
         self.idx = max(0, self.idx - 1)
         self.render()
 
     def next(self):
-        if self.sample_df is None: return
-        self.comments[self.idx] = self.comment_box.get("0.0", "end").strip()
+        if self.sample_df is None:
+            return
+        self.comments[self.idx] = _get_text(self.comment_box).strip()
         self.idx = min(len(self.sample_df) - 1, self.idx + 1)
         self.render()
 
-    # Open in PO: only open the URL present in current row
-    
+    # Diverse handlinger
     def open_in_po(self):
-        # Åpner alltid standard PowerOffice-rapport (uten å lete etter lenker i data)
         import webbrowser
 
         webbrowser.open(OPEN_PO_URL)
         self._show_inline("Åpner PowerOffice")
-    
+
     def copy_invoice(self):
-        self._ensure_helpers()
-        if self.sample_df is None: return
+        if self.sample_df is None:
+            return
         inv_val = to_str(self.sample_df.iloc[self.idx].get(self.invoice_col, ""))
         cleaned = re.sub(r"[^\d-]", "", inv_val)
-        self.clipboard_clear(); self.clipboard_append(cleaned if cleaned else inv_val)
-        self.copy_feedback.configure(text="Kopiert")
-        self.after(1500, lambda: self.copy_feedback.configure(text=""))
+        QtWidgets.QApplication.clipboard().setText(cleaned if cleaned else inv_val)
+        _set_text(self.copy_feedback, "Kopiert")
+        QtCore.QTimer.singleShot(1500, lambda: _set_text(self.copy_feedback, ""))
 
-    # Ledger
-    # Summary / status
+    def export_pdf(self):
+        from report import export_pdf
+
+        export_pdf(self)
+
+    # Statuskort
     def _update_status_card(self):
-        self._ensure_helpers()
-        from data_utils import calc_sum_kontrollert, calc_sum_net_all
         sum_k = calc_sum_kontrollert(self.sample_df, self.decisions)
         sum_a = calc_sum_net_all(self.df)
         pct = (sum_k / sum_a * Decimal("100")) if sum_a else Decimal("0")
-        self.lbl_st_sum_kontrollert.configure(text=f"Sum kontrollert: {fmt_money(sum_k)} kr")
-        self.lbl_st_sum_alle.configure(text=f"Sum alle bilag: {fmt_money(sum_a)} kr")
-        self.lbl_st_pct.configure(text=f"% kontrollert av sum: {fmt_pct(pct)}")
+        _set_text(self.lbl_st_sum_kontrollert, f"Sum kontrollert: {fmt_money(sum_k)} kr")
+        _set_text(self.lbl_st_sum_alle, f"Sum alle bilag: {fmt_money(sum_a)} kr")
+        _set_text(self.lbl_st_pct, f"% kontrollert av sum: {fmt_pct(pct)}")
         if self.sample_df is not None:
             approved = sum(1 for d in self.decisions if d == "Godkjent")
             rejected = sum(1 for d in self.decisions if d == "Ikke godkjent")
             remaining = sum(1 for d in self.decisions if d is None)
-            self.lbl_st_godkjent.configure(text=f"Godkjent: {approved}")
-            self.lbl_st_ikkegodkjent.configure(text=f"Ikke godkjent: {rejected}")
-            self.lbl_st_gjen.configure(text=f"Gjenstår å kontrollere: {remaining}")
+            _set_text(self.lbl_st_godkjent, f"Godkjent: {approved}")
+            _set_text(self.lbl_st_ikkegodkjent, f"Ikke godkjent: {rejected}")
+            _set_text(self.lbl_st_gjen, f"Gjenstår å kontrollere: {remaining}")
             if remaining == 0 and not self._pdf_prompt_shown:
-                from tkinter import messagebox
-                from report import export_pdf
-                from .busy import show_busy, hide_busy, run_in_thread
-
                 self._pdf_prompt_shown = True
-                if messagebox.askyesno(APP_TITLE, "Ønsker du å eksportere PDF rapport?"):
-                    show_busy(self, "Eksporterer rapport...")
-
-                    def finalize():
-                        self._finish_progress()
-                        hide_busy(self)
-
-                    def worker():
-                        self.after(0, lambda: self._start_progress("Eksporterer rapport..."))
-                        try:
-                            export_pdf(self)
-                        finally:
-                            self.after(0, finalize)
-
-                    run_in_thread(worker)
+                if QtWidgets.QMessageBox.question(
+                    self,
+                    APP_TITLE,
+                    "Ønsker du å eksportere PDF rapport?",
+                ) == QtWidgets.QMessageBox.Yes:
+                    self.export_pdf()
         else:
-            self.lbl_st_godkjent.configure(text="Godkjent: –")
-            self.lbl_st_ikkegodkjent.configure(text="Ikke godkjent: –")
-            self.lbl_st_gjen.configure(text="Gjenstår å kontrollere: –")
+            _set_text(self.lbl_st_godkjent, "Godkjent: –")
+            _set_text(self.lbl_st_ikkegodkjent, "Ikke godkjent: –")
+            _set_text(self.lbl_st_gjen, "Gjenstår å kontrollere: –")
 
-    # Status
-    def _start_progress(self, msg: str):
+    # Statuslinje
+    def _start_progress(self, msg: str) -> None:
         self._progress_msg = msg
         self._progress_val = 0
         self._progress_running = True
         self._set_status(msg, 0)
-        self._progress_job = self.after(100, self._progress_step)
+        if self._progress_timer is None:
+            self._progress_timer = QtCore.QTimer(self)
+            self._progress_timer.timeout.connect(self._progress_step)
+        self._progress_timer.start(100)
 
-    def _progress_step(self):
+    def _progress_step(self) -> None:
         if not self._progress_running:
             return
         self._progress_val = min(95, self._progress_val + 2)
         self._set_status(self._progress_msg, self._progress_val)
-        self._progress_job = self.after(100, self._progress_step)
 
-    def _finish_progress(self):
+    def _finish_progress(self) -> None:
         self._progress_running = False
-        if self._progress_job is not None:
-            self.after_cancel(self._progress_job)
-            self._progress_job = None
+        if self._progress_timer:
+            self._progress_timer.stop()
         self._set_status(self._progress_msg, 100)
-        self.after(500, lambda: self._set_status(""))
+        QtCore.QTimer.singleShot(500, lambda: self._set_status(""))
 
-    def _set_status(self, msg: str, progress: float | None = None):
+    def _set_status(self, msg: str, progress: Optional[float] = None) -> None:
         if hasattr(self, "status_label"):
             if progress is not None:
-                self.status_label.configure(text=f"{msg} {progress:.0f}%")
+                _set_text(self.status_label, f"{msg} {progress:.0f}%")
             else:
-                self.status_label.configure(text=msg)
-            self.status_label.update_idletasks()
+                _set_text(self.status_label, msg)
         if hasattr(self, "progress_bar"):
             if progress is not None:
-                self.progress_bar.grid(**getattr(self, "progress_bar_grid", {}))
-                self.progress_bar.set(max(0, min(1, progress / 100)))
-                self.progress_bar.update_idletasks()
+                self.progress_bar.setVisible(True)
+                self.progress_bar.setValue(int(max(0, min(100, progress))))
             else:
-                self.progress_bar.grid_remove()
+                self.progress_bar.setVisible(False)
 
-    # PDF
     # Inline
-    def _show_inline(self, msg: str, ok=True):
-        self.inline_status.configure(
-            text_color=(style.get_color("success") if ok else style.get_color("error"))
-        )
-        self.inline_status.configure(text=msg)
-        self.after(3500, lambda: self.inline_status.configure(text=""))
+    def _show_inline(self, msg: str, ok: bool = True) -> None:
+        color = style.get_color("success" if ok else "error")
+        if hasattr(self.inline_status, "setStyleSheet"):
+            self.inline_status.setStyleSheet(f"color: {color};")
+        _set_text(self.inline_status, msg)
+        QtCore.QTimer.singleShot(3500, lambda: _set_text(self.inline_status, ""))
 
-    # Details + render
+    # Detaljer
     def _details_text_for_row(self, row_dict):
-        self._ensure_helpers()
-        lines=[]
-        for k in self.sample_df.columns:
-            key=str(k)
+        lines = []
+        for key, val in row_dict.items():
             if key.startswith("_"):
                 continue
-            val=to_str(row_dict.get(key,"")).strip()
-            if not val: continue
-            disp = val if (key.lower().startswith("faktura") and "nr" in key.lower()) else format_number_with_thousands(val)
+            disp = val
+            if not key.lower().startswith("faktura") or "nr" not in key.lower():
+                disp = format_number_with_thousands(val)
             lines.append(f"{key}: {disp}")
         return "\n".join(lines).strip()
 
-    def _update_status_label(self, status: str | None, placeholder: str = "—"):
-        if not hasattr(self, "lbl_status"):
-            return
-
+    def _update_status_label(self, status: Optional[str], placeholder: str = "—"):
         text = status if status else placeholder
-
+        color = style.get_color("fg")
         if status == "Godkjent":
-            font = style.FONT_TITLE or style.FONT_TITLE_LITE or style.FONT_BODY
             color = style.get_color("success")
         elif status == "Ikke godkjent":
-            font = style.FONT_TITLE or style.FONT_TITLE_LITE or style.FONT_BODY
             color = style.get_color("error")
-        else:
-            font = style.FONT_TITLE_LITE or style.FONT_BODY
-            color = style.get_color("fg")
-
-        self.lbl_status.configure(text=text, font=font, text_color=color)
+        if hasattr(self.lbl_status, "setStyleSheet"):
+            self.lbl_status.setStyleSheet(f"color: {color}; font-weight: bold;")
+        _set_text(self.lbl_status, text)
 
     def _update_status_card_safe(self):
         try:
@@ -825,65 +566,74 @@ class App:
             logger.exception("Feil ved oppdatering av statuskort")
 
     def render(self):
-        self._ensure_helpers()
         self._update_counts_labels()
-        if self.sample_df is not None and len(self.sample_df)>0:
-            self.lbl_count.configure(text=f"Bilag: {self.idx+1}/{len(self.sample_df)}")
-            inv_val = to_str(self.sample_df.iloc[self.idx].get(self.invoice_col, "")) if len(self.sample_df)>0 else "—"
-            self.lbl_invoice.configure(text=f"Fakturanr: {inv_val or '—'}")
+        if self.sample_df is not None and len(self.sample_df) > 0:
+            _set_text(self.lbl_count, f"Bilag: {self.idx + 1}/{len(self.sample_df)}")
+            inv_val = to_str(self.sample_df.iloc[self.idx].get(self.invoice_col, ""))
+            _set_text(self.lbl_invoice, f"Fakturanr: {inv_val or '—'}")
             st = self.decisions[self.idx] if (self.decisions and self.idx < len(self.decisions)) else None
             self._update_status_label(st)
-
             row_dict = self._current_row_dict()
-            self.detail_box.configure(state="normal"); self.detail_box.delete("0.0","end")
-            self.detail_box.insert("0.0", self._details_text_for_row(row_dict)); self.detail_box.configure(state="disabled")
-
-            if hasattr(self, "populate_ledger_table") and hasattr(self, "ledger_tree"):
-                self.populate_ledger_table(self, inv_val)
+            _clear_text(self.detail_box)
+            _insert_text(self.detail_box, self._details_text_for_row(row_dict))
+            if hasattr(self, "ledger_table") and self.gl_df is not None:
+                populate_ledger_table(self, inv_val)
             else:
-                if hasattr(self, "ledger_tree"):
-                    for item in self.ledger_tree.get_children():
-                        self.ledger_tree.delete(item)
+                if hasattr(self, "ledger_table"):
+                    while self.ledger_table.rowCount():
+                        self.ledger_table.removeRow(0)
                 if hasattr(self, "ledger_sum"):
                     msg = (
                         "Last gjerne også inn en hovedbok for å se bilagslinjene."
-                        if getattr(self, "gl_df", None) is None
+                        if self.gl_df is None
                         else ""
                     )
-                    self.ledger_sum.configure(text=msg)
-
-            self.comment_box.delete("0.0","end")
+                    _set_text(self.ledger_sum, msg)
+            _clear_text(self.comment_box)
             if self.comments and self.idx < len(self.comments) and self.comments[self.idx]:
-                self.comment_box.insert("0.0", self.comments[self.idx])
+                _insert_text(self.comment_box, self.comments[self.idx])
         else:
-            self.lbl_count.configure(text="Bilag: –/–")
-            self.lbl_invoice.configure(text="Fakturanr: –")
+            _set_text(self.lbl_count, "Bilag: –/–")
+            _set_text(self.lbl_invoice, "Fakturanr: –")
             self._update_status_label(None, placeholder="–")
-            self.detail_box.configure(state="normal"); self.detail_box.delete("0.0","end"); self.detail_box.insert("0.0","Velg Excel-fil og lag et utvalg."); self.detail_box.configure(state="disabled")
-            if hasattr(self, "ledger_tree"):
-                for item in self.ledger_tree.get_children():
-                    self.ledger_tree.delete(item)
+            _clear_text(self.detail_box)
+            _insert_text(self.detail_box, "Velg Excel-fil og lag et utvalg.")
+            if hasattr(self, "ledger_table"):
+                while self.ledger_table.rowCount():
+                    self.ledger_table.removeRow(0)
             if hasattr(self, "ledger_sum"):
                 msg = (
                     "Last gjerne også inn en hovedbok for å se bilagslinjene."
-                    if getattr(self, "gl_df", None) is None
+                    if self.gl_df is None
                     else "Trekk utvalg for å se bilagslinjene."
                 )
-                self.ledger_sum.configure(text=msg)
-            self.comment_box.delete("0.0","end")
+                _set_text(self.ledger_sum, msg)
+            _clear_text(self.comment_box)
 
         if self.sample_df is None or len(self.sample_df) == 0:
-            self.btn_prev.configure(state="disabled")
-            self.btn_next.configure(state="disabled")
+            _set_enabled(self.btn_prev, False)
+            _set_enabled(self.btn_next, False)
         else:
-            self.btn_prev.configure(state="normal" if self.idx > 0 else "disabled")
-            self.btn_next.configure(state="normal" if self.idx < len(self.sample_df) - 1 else "disabled")
+            _set_enabled(self.btn_prev, self.idx > 0)
+            _set_enabled(self.btn_next, self.idx < len(self.sample_df) - 1)
 
-        if (
-            (self.df is not None and len(self.df) > 0)
-            or (self.sample_df is not None and len(self.sample_df) > 0)
-        ):
+        if (self.df is not None and len(self.df) > 0) or (self.sample_df is not None and len(self.sample_df) > 0):
             self._update_status_card_safe()
 
-if __name__ == "__main__":
-    App().mainloop()
+    def _switch_theme(self, mode: str) -> None:
+        mode = (mode or "").strip()
+        style.set_theme(mode.lower())
+        apply_palette(self._qt_app)
+        if hasattr(self.theme_menu, "blockSignals"):
+            self.theme_menu.blockSignals(True)
+            idx = 0 if mode.lower() != "dark" else 1
+            self.theme_menu.setCurrentIndex(idx)
+            self.theme_menu.blockSignals(False)
+        if hasattr(self.sidebar, "refresh_theme"):
+            self.sidebar.refresh_theme()
+        if hasattr(self, "ledger_table") and hasattr(self.ledger_table, "refresh_theme"):
+            self.ledger_table.refresh_theme()
+        self.render()
+
+
+__all__ = ["App", "SimpleVar"]

--- a/gui/busy.py
+++ b/gui/busy.py
@@ -1,47 +1,73 @@
-import threading
-from tkinter import TclError
+from __future__ import annotations
 
-from helpers import logger
-from . import _ctk
+import threading
+from typing import Callable, Optional
+
+from PyQt5 import QtCore, QtWidgets
+
 from .style import PADDING_X, PADDING_Y
 
 
-def run_in_thread(func, *args):
-    """Start ``func`` i en bakgrunnstråd og returner trådobjektet."""
-    thread = threading.Thread(target=func, args=args, daemon=True)
+class _Worker(QtCore.QThread):
+    finished = QtCore.pyqtSignal(object)
+    failed = QtCore.pyqtSignal(Exception)
+
+    def __init__(self, func: Callable, *args, **kwargs) -> None:
+        super().__init__()
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+
+    def run(self) -> None:  # noqa: D401 - PyQt signatur
+        try:
+            result = self._func(*self._args, **self._kwargs)
+        except Exception as exc:  # pragma: no cover - propagert til GUI
+            self.failed.emit(exc)
+        else:
+            self.finished.emit(result)
+
+
+def run_in_thread(func: Callable, *args, **kwargs) -> threading.Thread:
+    """Behold API fra Tk-versjonen for bakoverkompatibilitet."""
+
+    thread = threading.Thread(target=func, args=args, kwargs=kwargs, daemon=True)
     thread.start()
     return thread
 
 
-def show_busy(app, message: str):
-    """Vis en modal ventedialog med en spinner og tekst."""
-    ctk = _ctk()
-    win = ctk.CTkToplevel(app)
-    win.title("")
-    win.resizable(False, False)
-    win.transient(app)
-    win.grab_set()
-
-    progress = ctk.CTkProgressBar(win, mode="indeterminate")
-    progress.pack(padx=PADDING_X * 2, pady=(PADDING_Y * 2, PADDING_Y), fill="x")
-    progress.start()
-    ctk.CTkLabel(win, text=message).pack(padx=PADDING_X * 2, pady=(0, PADDING_Y * 2))
-
-    app._busy_win = win
-    win.update_idletasks()
-    x = app.winfo_x() + app.winfo_width() // 2 - win.winfo_width() // 2
-    y = app.winfo_y() + app.winfo_height() // 2 - win.winfo_height() // 2
-    win.geometry(f"+{x}+{y}")
-    return win
+def start_worker(func: Callable, *args, on_success: Callable[[object], None], on_error: Callable[[Exception], None], **kwargs) -> _Worker:
+    worker = _Worker(func, *args, **kwargs)
+    worker.finished.connect(on_success)
+    worker.failed.connect(on_error)
+    worker.start()
+    return worker
 
 
-def hide_busy(app):
-    """Lukk ventedialogen hvis den er åpen."""
-    win = getattr(app, "_busy_win", None)
-    if win is not None:
-        try:
-            win.grab_release()
-        except TclError:
-            logger.debug("Kunne ikke frigjøre vinduets grab")
-        win.destroy()
-        app._busy_win = None
+def show_busy(parent: QtWidgets.QWidget, message: str) -> QtWidgets.QDialog:
+    dialog = QtWidgets.QDialog(parent)
+    dialog.setModal(True)
+    dialog.setWindowTitle("")
+    dialog.setWindowFlags(dialog.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+
+    layout = QtWidgets.QVBoxLayout(dialog)
+    layout.setContentsMargins(PADDING_X * 2, PADDING_Y * 2, PADDING_X * 2, PADDING_Y * 2)
+    layout.setSpacing(PADDING_Y * 2)
+
+    label = QtWidgets.QLabel(message, dialog)
+    layout.addWidget(label)
+
+    progress = QtWidgets.QProgressBar(dialog)
+    progress.setRange(0, 0)
+    layout.addWidget(progress)
+
+    dialog.resize(label.sizeHint().width() + PADDING_X * 4, dialog.sizeHint().height())
+    dialog.show()
+    parent._busy_dialog = dialog
+    return dialog
+
+
+def hide_busy(parent: QtWidgets.QWidget) -> None:
+    dialog: Optional[QtWidgets.QDialog] = getattr(parent, "_busy_dialog", None)
+    if dialog is not None:
+        dialog.accept()
+        parent._busy_dialog = None

--- a/gui/busy.py
+++ b/gui/busy.py
@@ -48,12 +48,15 @@ def show_busy(parent: QtWidgets.QWidget, message: str) -> QtWidgets.QDialog:
     dialog.setModal(True)
     dialog.setWindowTitle("")
     dialog.setWindowFlags(dialog.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+    dialog.setObjectName("BusyDialog")
+    dialog.setAttribute(QtCore.Qt.WA_StyledBackground, True)
 
     layout = QtWidgets.QVBoxLayout(dialog)
     layout.setContentsMargins(PADDING_X * 2, PADDING_Y * 2, PADDING_X * 2, PADDING_Y * 2)
     layout.setSpacing(PADDING_Y * 2)
 
     label = QtWidgets.QLabel(message, dialog)
+    label.setProperty("role", "muted")
     layout.addWidget(label)
 
     progress = QtWidgets.QProgressBar(dialog)

--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -12,7 +12,7 @@ class DropZone(QtWidgets.QFrame):
         super().__init__(parent)
         self._normal_border = style.get_color("dnd_border")
         self._normal_bg = style.get_color("dnd_bg")
-        self._highlight = style.get_color("success")
+        self._highlight = style.get_color("accent")
         self.setFrameShape(QtWidgets.QFrame.StyledPanel)
         self.setAcceptDrops(True)
         self.setObjectName("dropZone")
@@ -23,6 +23,7 @@ class DropZone(QtWidgets.QFrame):
 
         self._label = QtWidgets.QLabel(text, self)
         self._label.setAlignment(QtCore.Qt.AlignCenter)
+        self._label.setWordWrap(True)
         layout.addWidget(self._label)
 
         self._update_colors(self._normal_bg, self._normal_border)
@@ -30,20 +31,21 @@ class DropZone(QtWidgets.QFrame):
     def refresh_theme(self) -> None:
         self._normal_border = style.get_color("dnd_border")
         self._normal_bg = style.get_color("dnd_bg")
-        self._highlight = style.get_color("success")
+        self._highlight = style.get_color("accent")
         self._update_colors(self._normal_bg, self._normal_border)
 
     def _update_colors(self, bg: str, border: str) -> None:
+        text_color = style.get_color("text_muted")
         self.setStyleSheet(
-            f"#dropZone {{background-color: {bg}; border: 2px dashed {border}; border-radius: 8px;}}"
-            f"#dropZone QLabel {{color: {border};}}"
+            f"#dropZone {{background-color: {bg}; border: 2px dashed {border}; border-radius: {style.CARD_RADIUS}px;}}"
+            f"#dropZone QLabel {{color: {text_color}; font-weight: 500;}}"
         )
 
     def dragEnterEvent(self, event: QtGui.QDragEnterEvent) -> None:  # noqa: N802
         if event.mimeData().hasUrls():
             event.acceptProposedAction()
             self._update_colors(self._highlight, self._highlight)
-            self._label.setStyleSheet(f"color: {style.get_color('fg')}")
+            self._label.setStyleSheet(f"color: {style.get_color('header_fg')}")
         else:
             event.ignore()
 

--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -1,54 +1,64 @@
-from . import _ctk
-from .style import style
+from PyQt5 import QtCore, QtGui, QtWidgets
 
-ctk = _ctk()
+from .style import style, PADDING_X, PADDING_Y
 
 
-class DropZone(ctk.CTkFrame):
-    """En ramme for dra-og-slipp med fargeendring ved drag hendelser."""
+class DropZone(QtWidgets.QFrame):
+    """En enkel PyQt-dra-og-slipp-sone med visuell tilbakemelding."""
 
-    def __init__(self, parent, text: str, drop_callback):
-        dnd_bg = style.get_color_pair("dnd_bg")
-        dnd_border = style.get_color_pair("dnd_border")
-        highlight = style.get_color_pair("success")
+    dropped = QtCore.pyqtSignal(str)
 
-        super().__init__(
-            parent,
-            height=70,
-            corner_radius=style.BTN_RADIUS,
-            fg_color=dnd_bg,
-            border_color=dnd_border,
-            border_width=2,
+    def __init__(self, parent: QtWidgets.QWidget, text: str):
+        super().__init__(parent)
+        self._normal_border = style.get_color("dnd_border")
+        self._normal_bg = style.get_color("dnd_bg")
+        self._highlight = style.get_color("success")
+        self.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.setAcceptDrops(True)
+        self.setObjectName("dropZone")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(PADDING_X * 2, PADDING_Y * 2, PADDING_X * 2, PADDING_Y * 2)
+        layout.setSpacing(PADDING_Y)
+
+        self._label = QtWidgets.QLabel(text, self)
+        self._label.setAlignment(QtCore.Qt.AlignCenter)
+        layout.addWidget(self._label)
+
+        self._update_colors(self._normal_bg, self._normal_border)
+
+    def refresh_theme(self) -> None:
+        self._normal_border = style.get_color("dnd_border")
+        self._normal_bg = style.get_color("dnd_bg")
+        self._highlight = style.get_color("success")
+        self._update_colors(self._normal_bg, self._normal_border)
+
+    def _update_colors(self, bg: str, border: str) -> None:
+        self.setStyleSheet(
+            f"#dropZone {{background-color: {bg}; border: 2px dashed {border}; border-radius: 8px;}}"
+            f"#dropZone QLabel {{color: {border};}}"
         )
 
-        self._dnd_bg = dnd_bg
-        self._dnd_border = dnd_border
-        self._highlight = highlight
-        self.drop_callback = drop_callback
-        self._label_text_color = dnd_border
+    def dragEnterEvent(self, event: QtGui.QDragEnterEvent) -> None:  # noqa: N802
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+            self._update_colors(self._highlight, self._highlight)
+            self._label.setStyleSheet(f"color: {style.get_color('fg')}")
+        else:
+            event.ignore()
 
-        self.label = ctk.CTkLabel(
-            self,
-            text=text,
-            anchor="center",
-            text_color=self._label_text_color,
-        )
-        self.label.pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
+    def dragLeaveEvent(self, event: QtGui.QDragLeaveEvent) -> None:  # noqa: N802
+        super().dragLeaveEvent(event)
+        self._label.setStyleSheet("")
+        self._update_colors(self._normal_bg, self._normal_border)
 
-        for evt in ("<<DragEnter>>", "<<DropEnter>>"):
-            self.dnd_bind(evt, self._on_drag_enter)
-        for evt in ("<<DragLeave>>", "<<DropLeave>>"):
-            self.dnd_bind(evt, self.reset_colors)
-
-    def _on_drag_enter(self, _):
-        self.configure(fg_color=self._highlight, border_color=self._highlight)
-        self.label.configure(text_color=style.get_color_pair("fg"))
-
-    def reset_colors(self, _=None):
-        self.configure(fg_color=self._dnd_bg, border_color=self._dnd_border)
-        self.label.configure(text_color=self._label_text_color)
-
-    def on_drop(self, event):
-        self.reset_colors()
-        if self.drop_callback:
-            return self.drop_callback(event)
+    def dropEvent(self, event: QtGui.QDropEvent) -> None:  # noqa: N802
+        event.setDropAction(QtCore.Qt.CopyAction)
+        event.accept()
+        self._label.setStyleSheet("")
+        self._update_colors(self._normal_bg, self._normal_border)
+        for url in event.mimeData().urls():
+            path = url.toLocalFile()
+            if path:
+                self.dropped.emit(path)
+                break

--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -24,6 +24,7 @@ class LedgerTable(QtWidgets.QTableWidget):
 
     def __init__(self, parent: QtWidgets.QWidget):
         super().__init__(0, len(LEDGER_COLS), parent)
+        self.setObjectName("LedgerTable")
         self.setHorizontalHeaderLabels(LEDGER_COLS)
         self.setAlternatingRowColors(True)
         self.verticalHeader().setVisible(False)
@@ -61,9 +62,17 @@ class LedgerTable(QtWidgets.QTableWidget):
 
     def refresh_theme(self) -> None:
         self.setStyleSheet(
-            "QTableWidget {border: 1px solid transparent;}"
-            f"QHeaderView::section {{background-color: {style.get_color('table_header_bg')};"
-            f" padding: {PADDING_Y}px {PADDING_X}px; border: 0px;}}"
+            "QTableWidget {"
+            f"background-color: {style.get_color('panel_bg')};"
+            f"border: 1px solid {style.get_color('panel_border')};"
+            f"border-radius: {style.CARD_RADIUS}px;"
+            f"gridline-color: {style.get_color('panel_border')};"
+            "}"
+            f"QHeaderView::section {{background-color: {style.get_color('button_bg')};"
+            f" color: {style.get_color('button_fg')};"
+            f" padding: {PADDING_Y}px {PADDING_X}px; border: none; font-weight: 600;}}"
+            f"QTableWidget::item:selected {{background-color: {style.get_color('table_sel_bg')};"
+            f" color: {style.get_color('table_sel_fg')};}}"
         )
 
 

--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -1,96 +1,73 @@
-LEDGER_COLS = ["Kontonr", "Konto", "Beskrivelse", "MVA", "MVA-beløp", "Beløp", "Postert av"]
+from __future__ import annotations
 
 from decimal import Decimal
+from typing import List
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+from helpers import fmt_money, only_digits, parse_amount, to_str
+from .style import style, PADDING_X, PADDING_Y
+
+LEDGER_COLS: List[str] = [
+    "Kontonr",
+    "Konto",
+    "Beskrivelse",
+    "MVA",
+    "MVA-beløp",
+    "Beløp",
+    "Postert av",
+]
 
 
-def apply_treeview_theme(app):
-    from tkinter import ttk, TclError
-    import customtkinter as ctk
-    from .style import style
+class LedgerTable(QtWidgets.QTableWidget):
+    """Tabell med hjelpefunksjoner for å etterligne Tkinter-API."""
 
-    ttk_style = ttk.Style()
-    try:
-        ttk_style.theme_use("clam")
-    except TclError:
-        pass
-    font = (
-        app.detail_box.cget("font")
-        if hasattr(app, "detail_box")
-        else ctk.CTkFont(size=14, family=style.FONT_FAMILY)
-    )
-    bg = style.get_color("table_bg")
-    fg = style.get_color("table_fg")
-    hb = style.get_color("table_header_bg")
-    sel_bg = style.get_color("table_sel_bg")
-    sel_fg = style.get_color("table_sel_fg")
-    ttk_style.configure(
-        "Custom.Treeview",
-        background=bg,
-        fieldbackground=bg,
-        foreground=fg,
-        rowheight=24,
-        borderwidth=0,
-        font=font,
-    )
-    ttk_style.configure(
-        "Custom.Treeview.Heading",
-        background=hb,
-        foreground=fg,
-        borderwidth=0,
-    )
-    ttk_style.map(
-        "Custom.Treeview",
-        background=[("selected", sel_bg)],
-        foreground=[("selected", sel_fg)],
-    )
-    app.ledger_tree.configure(style="Custom.Treeview")
+    def __init__(self, parent: QtWidgets.QWidget):
+        super().__init__(0, len(LEDGER_COLS), parent)
+        self.setHorizontalHeaderLabels(LEDGER_COLS)
+        self.setAlternatingRowColors(True)
+        self.verticalHeader().setVisible(False)
+        self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().setHighlightSections(False)
+        self.refresh_theme()
 
+    # Tk-kompatible hjelpere
+    def get_children(self):  # noqa: D401 - beholder API
+        return range(self.rowCount())
 
-def update_treeview_stripes(app):
-    from .style import style
+    def delete(self, row, *_):  # noqa: D401 - beholder API
+        self.removeRow(row)
 
-    odd = style.get_color("table_row_odd")
-    even = style.get_color("table_row_even")
-    app.ledger_tree.tag_configure("odd", background=odd)
-    app.ledger_tree.tag_configure("even", background=even)
+    def insert(self, _parent, _index, values, tags=None):  # noqa: ANN001 - Tk API
+        row = self.rowCount()
+        self.insertRow(row)
+        for col, value in enumerate(values):
+            item = QtWidgets.QTableWidgetItem(str(value))
+            item.setFlags(item.flags() ^ QtCore.Qt.ItemIsEditable)
+            self.setItem(row, col, item)
+        if tags:
+            if "odd" in tags:
+                self.setRowBackground(row, style.get_color("table_row_odd"))
+            elif "even" in tags:
+                self.setRowBackground(row, style.get_color("table_row_even"))
 
+    def setRowBackground(self, row: int, color: str) -> None:  # noqa: N802 - Qt navnestil
+        for col in range(self.columnCount()):
+            item = self.item(row, col)
+            if item:
+                item.setBackground(QtGui.QColor(color))
 
-def sort_treeview(tree, col, reverse, app):
-    """Sorter rader i ``tree`` etter valgt kolonne."""
-    from helpers import parse_amount
-
-    data = []
-    for iid in tree.get_children(""):
-        cell = tree.set(iid, col)
-        num = parse_amount(cell)
-        sort_val = num if num is not None else str(cell).lower()
-        data.append((sort_val, iid))
-    data.sort(reverse=reverse)
-    for idx, (_, iid) in enumerate(data):
-        tree.move(iid, "", idx)
-    for idx, iid in enumerate(tree.get_children("")):
-        tag = "even" if idx % 2 == 0 else "odd"
-        tree.item(iid, tags=(tag,))
-    arrow = "↓" if reverse else "↑"
-    for c in LEDGER_COLS:
-        if c == col:
-            tree.heading(
-                c,
-                text=f"{c} {arrow}",
-                command=lambda c=c: sort_treeview(tree, c, not reverse, app),
-            )
-        else:
-            tree.heading(
-                c, text=c, command=lambda c=c: sort_treeview(tree, c, False, app)
-            )
-    update_treeview_stripes(app)
+    def refresh_theme(self) -> None:
+        self.setStyleSheet(
+            "QTableWidget {border: 1px solid transparent;}"
+            f"QHeaderView::section {{background-color: {style.get_color('table_header_bg')};"
+            f" padding: {PADDING_Y}px {PADDING_X}px; border: 0px;}}"
+        )
 
 
 def ledger_rows(app, invoice_value: str):
-    """Hent bilagslinjer for gitt bilagsnummer uten å endre ``gl_df``."""
-    import re
-    from helpers import to_str, only_digits, parse_amount, fmt_money
-
     if app.gl_df is None or not hasattr(app, "gl_index"):
         return []
     key = only_digits(invoice_value)
@@ -99,106 +76,55 @@ def ledger_rows(app, invoice_value: str):
     idxs = app.gl_index.get(key)
     if idxs is None or len(idxs) == 0:
         return []
-    # ``groupby().indices`` returnerer numpy-arrays; ``len`` fungerer for å
-    # sjekke tomme treff uten å utløse "ambiguous truth value".
     hits = app.gl_df.loc[idxs]
     rows = []
     for _, r in hits.iterrows():
         konto_nr = to_str(r.get(app.gl_accountno_col, ""))
-        if not konto_nr:
-            cand = to_str(r.get(app.gl_accountname_col, ""))
-            m = re.match(r"^\s*(\d{3,6})\b", cand)
-            if m:
-                konto_nr = m.group(1)
         konto_navn = to_str(r.get(app.gl_accountname_col, ""))
-        if not konto_navn:
-            combo = to_str(r.get(app.gl_accountno_col, ""))
-            m = re.match(r"^\s*(\d{3,6})\s*[-–:]?\s*(.+)$", combo)
-            if m:
-                if not konto_nr:
-                    konto_nr = m.group(1)
-                konto_navn = m.group(2)
+        if not konto_nr and konto_navn:
+            parts = konto_navn.split()
+            if parts and parts[0].isdigit():
+                konto_nr = parts[0]
+        if not konto_navn and konto_nr:
+            konto_navn = konto_nr
         beskr = to_str(r.get(app.gl_desc_col, "")) or to_str(r.get(app.gl_text_col, ""))
         mva_code = to_str(r.get(app.gl_vatcode_col, ""))
         mva_belop = fmt_money(r.get(app.gl_vatamount_col, ""))
-        deb = parse_amount(r.get(app.gl_debit_col)) if app.gl_debit_col else None
-        kre = parse_amount(r.get(app.gl_credit_col)) if app.gl_credit_col else None
         belop = parse_amount(r.get(app.gl_amount_col)) if app.gl_amount_col else None
-        if belop is None and (deb is not None or kre is not None):
-            belop = (
-                (deb if deb is not None else Decimal("0"))
-                - (kre if kre is not None else Decimal("0"))
-            )
+        if belop is None:
+            deb = parse_amount(r.get(app.gl_debit_col)) if app.gl_debit_col else None
+            kre = parse_amount(r.get(app.gl_credit_col)) if app.gl_credit_col else None
+            belop = (deb or Decimal("0")) - (kre or Decimal("0"))
         belop_str = fmt_money(belop)
         postert_av = to_str(r.get(app.gl_postedby_col, ""))
-        rows.append({
-            "Kontonr": konto_nr,
-            "Konto": konto_navn,
-            "Beskrivelse": beskr,
-            "MVA": mva_code,
-            "MVA-beløp": mva_belop,
-            "Beløp": belop_str,
-            "Postert av": postert_av,
-        })
+        rows.append(
+            {
+                "Kontonr": konto_nr,
+                "Konto": konto_navn,
+                "Beskrivelse": beskr,
+                "MVA": mva_code,
+                "MVA-beløp": mva_belop,
+                "Beløp": belop_str,
+                "Postert av": postert_av,
+            }
+        )
     return rows
 
 
-def autofit_tree_columns(tree, cols, total_width=None):
-    import tkinter.font as tkfont
-    from tkinter import ttk
-    from .style import PADDING_X
-
-    if total_width is None:
-        tree.update_idletasks()
-        total_width = tree.winfo_width()
-
-    ttk_style = ttk.Style()
-    font_name = ttk_style.lookup(tree.cget("style"), "font") or "TkDefaultFont"
-    body_font = tkfont.nametofont(font_name)
-    head_font_name = ttk_style.lookup(f"{tree.cget('style')}.Heading", "font")
-    head_font = tkfont.nametofont(head_font_name) if head_font_name else body_font
-
-    widths: list[int] = []
-    MIN_COL_WIDTH = PADDING_X * 4
-    for col in cols:
-        max_px = head_font.measure(col)
-        for iid in tree.get_children(""):
-            txt = str(tree.set(iid, col))
-            px = body_font.measure(txt)
-            if px > max_px:
-                max_px = px
-        max_px += PADDING_X * 4
-        max_px = max(MIN_COL_WIDTH, min(max_px, 500))
-        widths.append(int(max_px))
-
-    total_content = sum(widths)
-    if total_width and total_content:
-        if total_content > total_width:
-            ratio = total_width / total_content
-            widths = [max(int(w * ratio), MIN_COL_WIDTH) for w in widths]
-        elif total_content < total_width:
-            extra = (total_width - total_content) // len(widths)
-            widths = [w + extra for w in widths]
-
-    for col, w in zip(cols, widths):
-        tree.column(col, width=w, minwidth=w)
-
-
 def populate_ledger_table(app, invoice_value: str):
-    from helpers import parse_amount, fmt_money
-
-    for item in app.ledger_tree.get_children():
-        app.ledger_tree.delete(item)
+    table: LedgerTable = app.ledger_table
+    while table.rowCount():
+        table.removeRow(0)
     rows = ledger_rows(app, invoice_value)
     if not rows:
         msg = "Ingen hovedbok lastet." if app.gl_df is None else "Ingen bilagslinjer for dette bilagsnummeret."
-        app.ledger_sum.configure(text=msg)
+        app.ledger_sum.setText(msg)
         return
     total = Decimal("0")
     for i, r in enumerate(rows):
         tags = ["even" if i % 2 == 0 else "odd"]
-        v = parse_amount(r["Beløp"])
-        total += (v if v is not None else Decimal("0"))
-        app.ledger_tree.insert("", "end", values=[r[c] for c in app.ledger_cols], tags=tags)
-    autofit_tree_columns(app.ledger_tree, app.ledger_cols)
-    app.ledger_sum.configure(text=f"Sum beløp: {fmt_money(total)}   •   Linjer: {len(rows)}")
+        val = parse_amount(r["Beløp"])
+        total += val or Decimal("0")
+        table.insert("", "end", [r[c] for c in LEDGER_COLS], tags=tags)
+    table.resizeColumnsToContents()
+    app.ledger_sum.setText(f"Sum beløp: {fmt_money(total)}   •   Linjer: {len(rows)}")

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PyQt5 import QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 from .ledger import LedgerTable
 from .style import PADDING_Y, style
@@ -10,7 +10,7 @@ class PlainTextBox(QtWidgets.QPlainTextEdit):
     def __init__(self, parent: QtWidgets.QWidget, read_only: bool = False):
         super().__init__(parent)
         self.setReadOnly(read_only)
-        self.setMinimumHeight(120)
+        self.setMinimumHeight(140)
 
     # Tk-kompatible hjelpere
     def configure(self, **kwargs):
@@ -35,13 +35,17 @@ class MainView(QtWidgets.QWidget):
     def __init__(self, app: "App"):
         super().__init__(app)
         self._app = app
+        self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, style.PAD_XL, style.PAD_XL, style.PAD_XL)
-        layout.setSpacing(style.PAD_MD)
+        layout.setSpacing(style.PAD_LG)
 
         header = self._build_header()
         layout.addWidget(header)
+
+        stats = self._build_stats_strip()
+        layout.addWidget(stats)
 
         actions = self._build_action_buttons()
         layout.addWidget(actions)
@@ -54,134 +58,264 @@ class MainView(QtWidgets.QWidget):
 
     def _build_header(self) -> QtWidgets.QWidget:
         app = self._app
-        widget = QtWidgets.QWidget(self)
-        layout = QtWidgets.QGridLayout(widget)
-        layout.setContentsMargins(style.PAD_LG, style.PAD_MD, style.PAD_LG, style.PAD_MD)
-        layout.setHorizontalSpacing(style.PAD_MD)
-        layout.setColumnStretch(6, 1)
+        frame = QtWidgets.QFrame(self)
+        frame.setObjectName("HeaderFrame")
+        frame.setAttribute(QtCore.Qt.WA_StyledBackground, True)
 
-        app.lbl_count = QtWidgets.QLabel("Bilag: –/–", widget)
-        layout.addWidget(app.lbl_count, 0, 0)
+        layout = QtWidgets.QHBoxLayout(frame)
+        layout.setContentsMargins(style.PAD_XL, style.PAD_LG, style.PAD_XL, style.PAD_LG)
+        layout.setSpacing(style.PAD_LG)
 
-        app.lbl_status_label = QtWidgets.QLabel("Status:", widget)
-        layout.addWidget(app.lbl_status_label, 0, 1)
+        title_column = QtWidgets.QVBoxLayout()
+        title_column.setSpacing(style.PAD_XXS)
 
-        app.lbl_status = QtWidgets.QLabel("–", widget)
-        layout.addWidget(app.lbl_status, 0, 2)
+        headline = QtWidgets.QLabel("Bilagskontroll", frame)
+        headline.setObjectName("HeaderTitle")
+        title_column.addWidget(headline)
 
-        app.lbl_invoice = QtWidgets.QLabel("Fakturanr: –", widget)
-        layout.addWidget(app.lbl_invoice, 0, 3)
+        subtitle = QtWidgets.QLabel("Kontroller og dokumenter leverandørbilag raskt", frame)
+        subtitle.setObjectName("HeaderSubtitle")
+        title_column.addWidget(subtitle)
+        title_column.addStretch(1)
 
-        copy_btn = QtWidgets.QPushButton("📋 Kopier fakturanr", widget)
-        copy_btn.clicked.connect(app.copy_invoice)
-        layout.addWidget(copy_btn, 0, 4)
+        layout.addLayout(title_column, 1)
 
-        app.copy_feedback = QtWidgets.QLabel("", widget)
-        layout.addWidget(app.copy_feedback, 0, 5)
+        controls = QtWidgets.QHBoxLayout()
+        controls.setSpacing(style.PAD_SM)
 
-        app.inline_status = QtWidgets.QLabel("", widget)
-        layout.addWidget(app.inline_status, 0, 6)
+        theme_label = QtWidgets.QLabel("Tema", frame)
+        theme_label.setProperty("role", "muted")
+        controls.addWidget(theme_label)
 
-        theme_label = QtWidgets.QLabel("Tema", widget)
-        layout.addWidget(theme_label, 0, 7)
-
-        app.theme_menu = QtWidgets.QComboBox(widget)
+        app.theme_menu = QtWidgets.QComboBox(frame)
         app.theme_menu.addItems(["Light", "Dark"])
         app.theme_menu.currentTextChanged.connect(app._switch_theme)
-        layout.addWidget(app.theme_menu, 0, 8)
+        app.theme_menu.setFixedWidth(120)
+        controls.addWidget(app.theme_menu)
 
-        return widget
+        layout.addLayout(controls)
+        return frame
+
+    def _build_stats_strip(self) -> QtWidgets.QWidget:
+        app = self._app
+        container = QtWidgets.QWidget(self)
+        outer = QtWidgets.QVBoxLayout(container)
+        outer.setContentsMargins(style.PAD_LG, style.PAD_MD, style.PAD_LG, style.PAD_MD)
+        outer.setSpacing(style.PAD_SM)
+
+        cards = QtWidgets.QHBoxLayout()
+        cards.setSpacing(style.PAD_MD)
+
+        count_card, count_label = self._make_stat_card(container, "Bilag i utvalg")
+        app.lbl_count = count_label
+        cards.addWidget(count_card)
+
+        status_card, status_label = self._make_stat_card(container, "Status")
+        app.lbl_status = status_label
+        cards.addWidget(status_card)
+
+        invoice_card, invoice_label, feedback_label = self._make_invoice_card(container)
+        app.lbl_invoice = invoice_label
+        app.copy_feedback = feedback_label
+        cards.addWidget(invoice_card)
+
+        outer.addLayout(cards)
+
+        inline = QtWidgets.QLabel("", container)
+        inline.setObjectName("InlineStatus")
+        inline.setProperty("role", "muted")
+        outer.addWidget(inline)
+        app.inline_status = inline
+
+        return container
+
+    def _make_stat_card(
+        self, parent: QtWidgets.QWidget, title: str
+    ) -> tuple[QtWidgets.QFrame, QtWidgets.QLabel]:
+        card = QtWidgets.QFrame(parent)
+        card.setProperty("role", "card")
+        card_layout = QtWidgets.QVBoxLayout(card)
+        card_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
+        card_layout.setSpacing(style.PAD_XS)
+
+        caption = QtWidgets.QLabel(title, card)
+        caption.setProperty("role", "caption")
+        card_layout.addWidget(caption)
+
+        value = QtWidgets.QLabel("–", card)
+        value.setObjectName("InfoCardValue")
+        value.setProperty("role", "value")
+        card_layout.addWidget(value)
+
+        return card, value
+
+    def _make_invoice_card(
+        self, parent: QtWidgets.QWidget
+    ) -> tuple[QtWidgets.QFrame, QtWidgets.QLabel, QtWidgets.QLabel]:
+        card = QtWidgets.QFrame(parent)
+        card.setProperty("role", "card")
+        card_layout = QtWidgets.QVBoxLayout(card)
+        card_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
+        card_layout.setSpacing(style.PAD_XS)
+
+        caption = QtWidgets.QLabel("Aktivt bilag", card)
+        caption.setProperty("role", "caption")
+        card_layout.addWidget(caption)
+
+        row = QtWidgets.QHBoxLayout()
+        row.setSpacing(style.PAD_XS)
+
+        label = QtWidgets.QLabel("Fakturanr: –", card)
+        label.setObjectName("InfoCardValue")
+        label.setProperty("role", "value")
+        row.addWidget(label, 1)
+
+        copy_btn = QtWidgets.QToolButton(card)
+        copy_btn.setProperty("role", "icon")
+        copy_btn.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
+        copy_icon = card.style().standardIcon(QtWidgets.QStyle.SP_FileDialogDetailedView)
+        copy_btn.setIcon(QtGui.QIcon.fromTheme("edit-copy", copy_icon))
+        copy_btn.setToolTip("Kopier fakturanummer")
+        copy_btn.clicked.connect(self._app.copy_invoice)
+        copy_btn.setIconSize(QtCore.QSize(18, 18))
+        row.addWidget(copy_btn)
+
+        card_layout.addLayout(row)
+
+        feedback = QtWidgets.QLabel("", card)
+        feedback.setObjectName("InlineFeedback")
+        feedback.setProperty("role", "muted")
+        card_layout.addWidget(feedback)
+
+        return card, label, feedback
 
     def _build_action_buttons(self) -> QtWidgets.QWidget:
         app = self._app
-        widget = QtWidgets.QWidget(self)
+        widget = QtWidgets.QFrame(self)
+        widget.setObjectName("ActionBar")
         layout = QtWidgets.QHBoxLayout(widget)
         layout.setContentsMargins(style.PAD_LG, 0, style.PAD_LG, 0)
         layout.setSpacing(style.PAD_SM)
 
-        approve = QtWidgets.QPushButton("✅ Godkjent", widget)
+        primary_group = QtWidgets.QHBoxLayout()
+        primary_group.setSpacing(style.PAD_SM)
+
+        approve = QtWidgets.QPushButton("Godkjenn", widget)
+        approve.setProperty("role", "primary")
+        approve.setIcon(widget.style().standardIcon(QtWidgets.QStyle.SP_DialogApplyButton))
         approve.clicked.connect(lambda: app.set_decision_and_next("Godkjent"))
-        layout.addWidget(approve)
+        primary_group.addWidget(approve)
 
-        reject = QtWidgets.QPushButton("⛔ Ikke godkjent", widget)
+        reject = QtWidgets.QPushButton("Ikke godkjent", widget)
+        reject.setProperty("role", "danger")
+        reject.setIcon(widget.style().standardIcon(QtWidgets.QStyle.SP_DialogCancelButton))
         reject.clicked.connect(lambda: app.set_decision_and_next("Ikke godkjent"))
-        layout.addWidget(reject)
+        primary_group.addWidget(reject)
 
-        open_po = QtWidgets.QPushButton("🔗 Åpne PowerOffice", widget)
+        open_po = QtWidgets.QPushButton("Åpne PowerOffice", widget)
+        open_po.setProperty("role", "secondary")
+        open_po.setIcon(widget.style().standardIcon(QtWidgets.QStyle.SP_DirLinkIcon))
         open_po.clicked.connect(app.open_in_po)
-        layout.addWidget(open_po)
+        primary_group.addWidget(open_po)
 
-        app.btn_prev = QtWidgets.QPushButton("⬅ Forrige", widget)
+        layout.addLayout(primary_group)
+        layout.addStretch(1)
+
+        nav_group = QtWidgets.QHBoxLayout()
+        nav_group.setSpacing(style.PAD_SM)
+
+        app.btn_prev = QtWidgets.QPushButton("Forrige", widget)
+        app.btn_prev.setProperty("role", "ghost")
+        app.btn_prev.setIcon(widget.style().standardIcon(QtWidgets.QStyle.SP_ArrowBack))
         app.btn_prev.clicked.connect(app.prev)
-        layout.addWidget(app.btn_prev)
+        app.btn_prev.setIconSize(QtCore.QSize(18, 18))
+        nav_group.addWidget(app.btn_prev)
 
-        app.btn_next = QtWidgets.QPushButton("➡ Neste", widget)
+        app.btn_next = QtWidgets.QPushButton("Neste", widget)
+        app.btn_next.setProperty("role", "ghost")
+        app.btn_next.setIcon(widget.style().standardIcon(QtWidgets.QStyle.SP_ArrowForward))
         app.btn_next.clicked.connect(app.next)
-        layout.addWidget(app.btn_next)
+        app.btn_next.setIconSize(QtCore.QSize(18, 18))
+        nav_group.addWidget(app.btn_next)
 
+        layout.addLayout(nav_group)
         return widget
 
     def _build_panes(self) -> QtWidgets.QWidget:
         app = self._app
-        widget = QtWidgets.QWidget(self)
-        layout = QtWidgets.QHBoxLayout(widget)
-        layout.setContentsMargins(style.PAD_LG, 0, style.PAD_LG, 0)
-        layout.setSpacing(style.PAD_MD)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal, self)
+        splitter.setObjectName("MainSplitter")
 
-        # Venstre panel
-        left = QtWidgets.QWidget(widget)
+        left = QtWidgets.QFrame(splitter)
         left_layout = QtWidgets.QVBoxLayout(left)
-        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.setContentsMargins(style.PAD_MD, 0, style.PAD_MD, 0)
         left_layout.setSpacing(PADDING_Y)
 
-        left_layout.addWidget(QtWidgets.QLabel("Detaljer for bilag", left))
+        detail_caption = QtWidgets.QLabel("Detaljer for bilag", left)
+        detail_caption.setProperty("role", "caption")
+        left_layout.addWidget(detail_caption)
 
         app.detail_box = PlainTextBox(left, read_only=True)
         left_layout.addWidget(app.detail_box, 1)
 
-        layout.addWidget(left, 1)
-
-        # Høyre panel
-        right = QtWidgets.QWidget(widget)
+        right = QtWidgets.QFrame(splitter)
         right_layout = QtWidgets.QVBoxLayout(right)
-        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setContentsMargins(style.PAD_MD, 0, style.PAD_MD, 0)
         right_layout.setSpacing(PADDING_Y)
 
-        right_layout.addWidget(QtWidgets.QLabel("Hovedbok (bilagslinjer)", right))
+        ledger_caption = QtWidgets.QLabel("Hovedbok (bilagslinjer)", right)
+        ledger_caption.setProperty("role", "caption")
+        right_layout.addWidget(ledger_caption)
 
         app.ledger_table = LedgerTable(right)
         right_layout.addWidget(app.ledger_table, 3)
 
         app.ledger_sum = QtWidgets.QLabel("", right)
+        app.ledger_sum.setProperty("role", "muted")
         right_layout.addWidget(app.ledger_sum)
 
-        right_layout.addWidget(QtWidgets.QLabel("Kommentar", right))
+        comment_caption = QtWidgets.QLabel("Kommentar", right)
+        comment_caption.setProperty("role", "caption")
+        right_layout.addWidget(comment_caption)
 
         app.comment_box = PlainTextBox(right, read_only=False)
         right_layout.addWidget(app.comment_box, 1)
 
-        layout.addWidget(right, 1)
+        splitter.setSizes([3, 5])
         app.right_frame = right
-        return widget
+        return splitter
 
     def _build_bottom(self) -> QtWidgets.QWidget:
         app = self._app
-        widget = QtWidgets.QWidget(self)
+        widget = QtWidgets.QFrame(self)
+        widget.setObjectName("FooterBar")
         layout = QtWidgets.QHBoxLayout(widget)
         layout.setContentsMargins(style.PAD_LG, 0, style.PAD_LG, 0)
         layout.setSpacing(style.PAD_SM)
 
-        export_btn = QtWidgets.QPushButton("📄 Eksporter PDF rapport", widget)
+        export_btn = QtWidgets.QPushButton("Eksporter PDF", widget)
+        export_btn.setProperty("role", "primary")
+        export_btn.setIcon(widget.style().standardIcon(QtWidgets.QStyle.SP_DialogSaveButton))
         export_btn.clicked.connect(app.export_pdf)
         layout.addWidget(export_btn)
 
         app.status_label = QtWidgets.QLabel("", widget)
+        app.status_label.setObjectName("StatusLabel")
+        app.status_label.setProperty("role", "muted")
         layout.addWidget(app.status_label, 1)
 
         app.progress_bar = QtWidgets.QProgressBar(widget)
-        app.progress_bar.setMaximumWidth(200)
+        app.progress_bar.setObjectName("StatusProgress")
+        app.progress_bar.setMaximumWidth(220)
         app.progress_bar.setRange(0, 100)
         app.progress_bar.setVisible(False)
+        app.progress_bar.setTextVisible(False)
         layout.addWidget(app.progress_bar)
 
         return widget
+
+    def refresh_theme(self) -> None:
+        # Qt stylesheets oppdateres globalt, men vi sørger for at tekstbokser følger temaet.
+        for box in (self._app.detail_box, self._app.comment_box):
+            if isinstance(box, PlainTextBox):
+                box.viewport().setAutoFillBackground(False)

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,317 +1,187 @@
-from . import DEFAULT_APPEARANCE_MODE, create_button
-from .style import style
-from .style import PADDING_Y
+from __future__ import annotations
+
+from PyQt5 import QtWidgets
+
+from .ledger import LedgerTable
+from .style import PADDING_Y, style
 
 
-def build_header(app):
-    """Bygg overskrift med status, fakturanr og temavalg."""
+class PlainTextBox(QtWidgets.QPlainTextEdit):
+    def __init__(self, parent: QtWidgets.QWidget, read_only: bool = False):
+        super().__init__(parent)
+        self.setReadOnly(read_only)
+        self.setMinimumHeight(120)
 
-    import customtkinter as ctk
+    # Tk-kompatible hjelpere
+    def configure(self, **kwargs):
+        state = kwargs.get("state")
+        if state == "disabled":
+            self.setReadOnly(True)
+        elif state == "normal":
+            self.setReadOnly(False)
 
-    panel = app.main_panel
-    head = ctk.CTkFrame(panel)
-    head.grid(row=0, column=0, sticky="ew", padx=style.PAD_LG, pady=style.PAD_MD)
-    head.grid_columnconfigure(6, weight=1)
+    def delete(self, *_):
+        self.clear()
 
-    head_font = style.FONT_TITLE_LITE
+    def insert(self, *_args):
+        text = _args[-1] if _args else ""
+        self.setPlainText(text)
 
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.FONT_TITLE)
-    status_frame = ctk.CTkFrame(head, fg_color="transparent")
-    status_frame.grid(row=0, column=1, padx=style.PAD_MD, sticky="w")
-    app.lbl_status_label = ctk.CTkLabel(status_frame, text="Status:", font=head_font)
-    app.lbl_status_label.grid(row=0, column=0, padx=(0, style.PAD_XXS))
-    app.lbl_status = ctk.CTkLabel(
-        status_frame,
-        text="–",
-        font=head_font,
-        text_color=style.get_color("fg"),
-    )
-    app.lbl_status.grid(row=0, column=1)
-    app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
-    app.lbl_count.grid(row=0, column=0, padx=(style.PAD_XS, style.PAD_LG))
-    app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
-    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
-    app.copy_feedback = ctk.CTkLabel(
-        head,
-        text="",
-        text_color=style.get_color("success"),
-        font=style.FONT_BODY,
-    )
-    app.copy_feedback.grid(row=0, column=4, padx=style.PAD_MD, sticky="w")
-
-    app.inline_status = ctk.CTkLabel(
-        head,
-        text="",
-        text_color=style.get_color("success"),
-        font=style.FONT_BODY,
-    )
-    app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
-
-    ctk.CTkLabel(head, text="Temavalg", font=style.FONT_BODY).grid(
-        row=0,
-        column=7,
-        padx=(style.PAD_MD, style.PAD_XS),
-    )
-    default_theme_label = DEFAULT_APPEARANCE_MODE.title()
-    app.theme_var = ctk.StringVar(value=default_theme_label)
-    app.theme_menu = ctk.CTkOptionMenu(
-        head,
-        variable=app.theme_var,
-        values=["Light", "Dark"],
-        command=app._switch_theme,
-    )
-    app.theme_menu.grid(row=0, column=8, padx=(0, style.PAD_MD))
-    app.theme_menu.set(default_theme_label)
-
-    return head
+    def get(self, *_):
+        return self.toPlainText()
 
 
-def build_action_buttons(app):
-    """Opprett handling- og navigasjonsknapper."""
+class MainView(QtWidgets.QWidget):
+    def __init__(self, app: "App"):
+        super().__init__(app)
+        self._app = app
 
-    import customtkinter as ctk
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, style.PAD_XL, style.PAD_XL, style.PAD_XL)
+        layout.setSpacing(style.PAD_MD)
 
-    panel = app.main_panel
-    btns = ctk.CTkFrame(panel)
-    btns.grid(row=1, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_XS))
-    btns.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
+        header = self._build_header()
+        layout.addWidget(header)
 
-    create_button(
-        btns,
-        text="✅ Godkjent",
-        fg_color=style.get_color("success"),
-        hover_color=style.get_color("success_hover"),
-        command=lambda: app.set_decision_and_next("Godkjent"),
-    ).grid(row=0, column=0, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    create_button(
-        btns,
-        text="⛔ Ikke godkjent",
-        fg_color=style.get_color("error"),
-        hover_color=style.get_color("error_hover"),
-        command=lambda: app.set_decision_and_next("Ikke godkjent"),
-    ).grid(row=0, column=1, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    create_button(btns, text="🔗 Åpne PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    app.btn_prev = create_button(btns, text="⬅ Forrige", command=app.prev)
-    app.btn_prev.grid(row=0, column=3, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
-    app.btn_next = create_button(btns, text="➡ Neste", command=app.next)
-    app.btn_next.grid(row=0, column=4, padx=style.PAD_SM, pady=style.PAD_SM, sticky="ew")
+        actions = self._build_action_buttons()
+        layout.addWidget(actions)
 
-    return btns
+        split = self._build_panes()
+        layout.addWidget(split, 1)
 
+        bottom = self._build_bottom()
+        layout.addWidget(bottom)
 
-def build_panes(app):
-    """Bygg venstre og høyre panel for detaljer og hovedbok."""
+    def _build_header(self) -> QtWidgets.QWidget:
+        app = self._app
+        widget = QtWidgets.QWidget(self)
+        layout = QtWidgets.QGridLayout(widget)
+        layout.setContentsMargins(style.PAD_LG, style.PAD_MD, style.PAD_LG, style.PAD_MD)
+        layout.setHorizontalSpacing(style.PAD_MD)
+        layout.setColumnStretch(6, 1)
 
-    import customtkinter as ctk
+        app.lbl_count = QtWidgets.QLabel("Bilag: –/–", widget)
+        layout.addWidget(app.lbl_count, 0, 0)
 
-    panel = app.main_panel
-    paned = ctk.CTkFrame(panel)
-    paned.grid(row=2, column=0, sticky="nsew", padx=style.PAD_LG, pady=(style.PAD_XS, style.PAD_SM))
-    paned.grid_columnconfigure((0, 1), weight=1, minsize=400)
-    paned.grid_rowconfigure(0, weight=1)
+        app.lbl_status_label = QtWidgets.QLabel("Status:", widget)
+        layout.addWidget(app.lbl_status_label, 0, 1)
 
-    left = ctk.CTkFrame(paned)
-    right = ctk.CTkFrame(paned)
-    left.grid(row=0, column=0, sticky="nsew")
-    right.grid(row=0, column=1, sticky="nsew")
-    app.right_frame = right
+        app.lbl_status = QtWidgets.QLabel("–", widget)
+        layout.addWidget(app.lbl_status, 0, 2)
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
-    left.grid_columnconfigure(0, weight=1)
-    left.grid_rowconfigure(1, weight=1, minsize=120)
-    app.detail_box = ctk.CTkTextbox(left, height=360, font=style.FONT_BODY)
-    app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(style.PAD_MD, style.PAD_SM), pady=(0, style.PAD_MD))
+        app.lbl_invoice = QtWidgets.QLabel("Fakturanr: –", widget)
+        layout.addWidget(app.lbl_invoice, 0, 3)
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL)\
-        .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))
-    right.grid_columnconfigure(0, weight=1)
-    right.grid_columnconfigure(1, weight=0)
-    right.grid_rowconfigure(1, weight=3, minsize=150)
-    right.grid_rowconfigure(5, weight=1, minsize=120)
+        copy_btn = QtWidgets.QPushButton("📋 Kopier fakturanr", widget)
+        copy_btn.clicked.connect(app.copy_invoice)
+        layout.addWidget(copy_btn, 0, 4)
 
-    ctk.CTkLabel(right, text="Kommentar", font=style.FONT_TITLE_SMALL)\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(style.PAD_MD, style.PAD_SM), pady=(style.PAD_MD, style.PAD_XS))
-    app.comment_box = ctk.CTkTextbox(right, font=style.FONT_SMALL)
-    app.comment_box.grid(
-        row=5,
-        column=0,
-        columnspan=2,
-        sticky="nsew",
-        padx=(style.PAD_MD, style.PAD_SM),
-        pady=(0, style.PAD_MD),
-    )
+        app.copy_feedback = QtWidgets.QLabel("", widget)
+        layout.addWidget(app.copy_feedback, 0, 5)
 
-    return paned
+        app.inline_status = QtWidgets.QLabel("", widget)
+        layout.addWidget(app.inline_status, 0, 6)
 
+        theme_label = QtWidgets.QLabel("Tema", widget)
+        layout.addWidget(theme_label, 0, 7)
 
-def build_bottom(app):
-    """Lag bunnseksjonen med eksportknapp og statusvisning."""
+        app.theme_menu = QtWidgets.QComboBox(widget)
+        app.theme_menu.addItems(["Light", "Dark"])
+        app.theme_menu.currentTextChanged.connect(app._switch_theme)
+        layout.addWidget(app.theme_menu, 0, 8)
 
-    import customtkinter as ctk
+        return widget
 
-    panel = app.main_panel
-    bottom = ctk.CTkFrame(panel)
-    bottom.grid(row=3, column=0, sticky="ew", padx=style.PAD_LG, pady=(0, style.PAD_MD))
-    bottom.grid_columnconfigure(1, weight=1)
-    app.bottom_frame = bottom
+    def _build_action_buttons(self) -> QtWidgets.QWidget:
+        app = self._app
+        widget = QtWidgets.QWidget(self)
+        layout = QtWidgets.QHBoxLayout(widget)
+        layout.setContentsMargins(style.PAD_LG, 0, style.PAD_LG, 0)
+        layout.setSpacing(style.PAD_SM)
 
-    def _export_pdf():
-        from report import export_pdf
-        from .busy import show_busy, hide_busy, run_in_thread
+        approve = QtWidgets.QPushButton("✅ Godkjent", widget)
+        approve.clicked.connect(lambda: app.set_decision_and_next("Godkjent"))
+        layout.addWidget(approve)
 
-        show_busy(app, "Eksporterer rapport...")
+        reject = QtWidgets.QPushButton("⛔ Ikke godkjent", widget)
+        reject.clicked.connect(lambda: app.set_decision_and_next("Ikke godkjent"))
+        layout.addWidget(reject)
 
-        def finalize():
-            app._finish_progress()
-            hide_busy(app)
+        open_po = QtWidgets.QPushButton("🔗 Åpne PowerOffice", widget)
+        open_po.clicked.connect(app.open_in_po)
+        layout.addWidget(open_po)
 
-        def worker():
-            app.after(0, lambda: app._start_progress("Eksporterer rapport..."))
-            try:
-                export_pdf(app)
-            finally:
-                app.after(0, finalize)
+        app.btn_prev = QtWidgets.QPushButton("⬅ Forrige", widget)
+        app.btn_prev.clicked.connect(app.prev)
+        layout.addWidget(app.btn_prev)
 
-        run_in_thread(worker)
+        app.btn_next = QtWidgets.QPushButton("➡ Neste", widget)
+        app.btn_next.clicked.connect(app.next)
+        layout.addWidget(app.btn_next)
 
-    export_btn = create_button(
-        bottom, text="📄 Eksporter PDF rapport", command=_export_pdf
-    )
-    export_btn.grid(
-        row=0,
-        column=0,
-        padx=(style.PAD_MD, style.PAD_SM),
-        pady=style.PAD_SM,
-        sticky="w",
-    )
+        return widget
 
-    app.status_label = ctk.CTkLabel(bottom, text="", font=style.FONT_BODY)
-    app.status_label.grid(
-        row=0,
-        column=1,
-        padx=style.PAD_SM,
-        pady=style.PAD_SM,
-        sticky="ew",
-    )
+    def _build_panes(self) -> QtWidgets.QWidget:
+        app = self._app
+        widget = QtWidgets.QWidget(self)
+        layout = QtWidgets.QHBoxLayout(widget)
+        layout.setContentsMargins(style.PAD_LG, 0, style.PAD_LG, 0)
+        layout.setSpacing(style.PAD_MD)
 
-    app.progress_bar = ctk.CTkProgressBar(
-        bottom,
-        width=120,
-        progress_color=style.get_color("success"),
-        fg_color=style.get_color("bg"),
-    )
-    app.progress_bar.set(0)
-    app.progress_bar_grid = {
-        "row": 0,
-        "column": 2,
-        "padx": style.PAD_SM,
-        "pady": style.PAD_SM,
-        "sticky": "e",
-    }
+        # Venstre panel
+        left = QtWidgets.QWidget(widget)
+        left_layout = QtWidgets.QVBoxLayout(left)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.setSpacing(PADDING_Y)
 
-    return bottom
+        left_layout.addWidget(QtWidgets.QLabel("Detaljer for bilag", left))
 
+        app.detail_box = PlainTextBox(left, read_only=True)
+        left_layout.addWidget(app.detail_box, 1)
 
-def build_main(app):
-    """Sett sammen hovedpanelet av alle delkomponenter."""
+        layout.addWidget(left, 1)
 
-    import customtkinter as ctk
+        # Høyre panel
+        right = QtWidgets.QWidget(widget)
+        right_layout = QtWidgets.QVBoxLayout(right)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(PADDING_Y)
 
-    panel = ctk.CTkFrame(app, corner_radius=16)
-    panel.grid(row=0, column=1, sticky="nsew", padx=(0, style.PAD_XL), pady=style.PAD_XL)
-    panel.grid_columnconfigure(0, weight=1)
-    panel.grid_rowconfigure(2, weight=1, minsize=300)
+        right_layout.addWidget(QtWidgets.QLabel("Hovedbok (bilagslinjer)", right))
 
-    app.main_panel = panel
+        app.ledger_table = LedgerTable(right)
+        right_layout.addWidget(app.ledger_table, 3)
 
-    build_header(app)
-    build_action_buttons(app)
-    build_panes(app)
-    build_bottom(app)
+        app.ledger_sum = QtWidgets.QLabel("", right)
+        right_layout.addWidget(app.ledger_sum)
 
-    return panel
+        right_layout.addWidget(QtWidgets.QLabel("Kommentar", right))
 
-def resize_ledger_columns(app):
-    """Tilpass kolonner i hovedboktabellen ved endring av bredde."""
+        app.comment_box = PlainTextBox(right, read_only=False)
+        right_layout.addWidget(app.comment_box, 1)
 
-    from . import ledger
-    width = app.ledger_tree.winfo_width()
-    if getattr(app, "_prev_ledger_width", None) == width:
-        return
+        layout.addWidget(right, 1)
+        app.right_frame = right
+        return widget
 
-    app._prev_ledger_width = width
-    app.after(
-        100,
-        lambda: ledger.autofit_tree_columns(
-            app.ledger_tree, app.ledger_cols, width
-        ),
-    )
+    def _build_bottom(self) -> QtWidgets.QWidget:
+        app = self._app
+        widget = QtWidgets.QWidget(self)
+        layout = QtWidgets.QHBoxLayout(widget)
+        layout.setContentsMargins(style.PAD_LG, 0, style.PAD_LG, 0)
+        layout.setSpacing(style.PAD_SM)
 
+        export_btn = QtWidgets.QPushButton("📄 Eksporter PDF rapport", widget)
+        export_btn.clicked.connect(app.export_pdf)
+        layout.addWidget(export_btn)
 
-def build_ledger_widgets(app):
-    """Bygg trevisning for hovedbok med rullefelt og summering."""
+        app.status_label = QtWidgets.QLabel("", widget)
+        layout.addWidget(app.status_label, 1)
 
-    from tkinter import ttk
-    import customtkinter as ctk
-    from .ledger import (
-        LEDGER_COLS,
-        apply_treeview_theme,
-        update_treeview_stripes,
-        sort_treeview,
-    )
+        app.progress_bar = QtWidgets.QProgressBar(widget)
+        app.progress_bar.setMaximumWidth(200)
+        app.progress_bar.setRange(0, 100)
+        app.progress_bar.setVisible(False)
+        layout.addWidget(app.progress_bar)
 
-    right = app.right_frame
-    app.ledger_cols = LEDGER_COLS
-    app.ledger_tree = ttk.Treeview(
-        right, columns=LEDGER_COLS, show="headings", height=10, style="Custom.Treeview"
-    )
-    for col, w, anchor in [
-        ("Kontonr", 90, "w"),
-        ("Konto", 180, "w"),
-        ("Beskrivelse", 260, "w"),
-        ("MVA", 70, "w"),
-        ("MVA-beløp", 110, "e"),
-        ("Beløp", 110, "e"),
-        ("Postert av", 140, "w"),
-    ]:
-        app.ledger_tree.heading(
-            col,
-            text=col,
-            command=lambda c=col: sort_treeview(app.ledger_tree, c, False, app),
-        )
-        app.ledger_tree.column(col, width=w, minwidth=60, anchor=anchor, stretch=True)
-
-    yscroll = ctk.CTkScrollbar(right, orientation="vertical", command=app.ledger_tree.yview)
-    xscroll = ctk.CTkScrollbar(right, orientation="horizontal", command=app.ledger_tree.xview)
-    app.ledger_tree.configure(yscrollcommand=yscroll.set, xscrollcommand=xscroll.set)
-    app.ledger_tree.grid(row=1, column=0, sticky="nsew")
-    yscroll.grid(row=1, column=1, sticky="ns")
-    xscroll.grid(row=2, column=0, sticky="ew")
-
-    app._prev_ledger_width = None
-    app._ledger_configure_id = app.ledger_tree.bind(
-        "<Configure>", lambda e: resize_ledger_columns(app)
-    )
-
-    apply_treeview_theme(app)
-    update_treeview_stripes(app)
-
-    if app.ledger_tree.get_children():
-        sort_treeview(app.ledger_tree, app.ledger_cols[0], False, app)
-
-    app.ledger_sum = ctk.CTkLabel(
-        right,
-        text=" ",
-        anchor="e",
-        justify="right",
-        font=style.FONT_BODY,
-    )
-    app.ledger_sum.grid(
-        row=3,
-        column=0,
-        columnspan=2,
-        sticky="ew",
-        padx=(0, style.PAD_LG),
-        pady=(style.PAD_SM, PADDING_Y),
-    )
+        return widget

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -20,20 +20,29 @@ def parse_dropped_path(path: str) -> Optional[str]:
     return path
 
 
-class SidebarWidget(QtWidgets.QWidget):
+class SidebarWidget(QtWidgets.QFrame):
     def __init__(self, app: "App"):
         super().__init__(app)
         self._app = app
+        self.setObjectName("Sidebar")
+        self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(style.PAD_XL, style.PAD_XL, style.PAD_XL, style.PAD_XL)
-        layout.setSpacing(style.PAD_MD)
+        layout.setSpacing(style.PAD_LG)
 
-        title = QtWidgets.QLabel("⚙️ Datautvalg", self)
-        title.setStyleSheet("font-weight: bold; font-size: 18px;")
+        title = QtWidgets.QLabel("Datautvalg", self)
+        title.setObjectName("SidebarTitle")
         layout.addWidget(title)
 
-        self.file_btn = QtWidgets.QPushButton("Velg leverandørfakturaer (Excel)…", self)
+        description = QtWidgets.QLabel("Velg eller slipp filer for å komme i gang.", self)
+        description.setObjectName("SidebarDescription")
+        description.setWordWrap(True)
+        layout.addWidget(description)
+
+        self.file_btn = QtWidgets.QPushButton("Velg leverandørfakturaer …", self)
+        self.file_btn.setProperty("role", "primary")
+        self.file_btn.setIcon(self.style().standardIcon(QtWidgets.QStyle.SP_FileIcon))
         self.file_btn.clicked.connect(app.choose_file)
         layout.addWidget(self.file_btn)
 
@@ -42,10 +51,13 @@ class SidebarWidget(QtWidgets.QWidget):
         layout.addWidget(self.inv_drop)
 
         self.file_path_label = QtWidgets.QLabel("", self)
+        self.file_path_label.setObjectName("PathLabel")
         self.file_path_label.setWordWrap(True)
         layout.addWidget(self.file_path_label)
 
-        self.gl_btn = QtWidgets.QPushButton("Velg hovedbok (Excel)…", self)
+        self.gl_btn = QtWidgets.QPushButton("Velg hovedbok …", self)
+        self.gl_btn.setProperty("role", "secondary")
+        self.gl_btn.setIcon(self.style().standardIcon(QtWidgets.QStyle.SP_DriveHDIcon))
         self.gl_btn.clicked.connect(app.choose_gl_file)
         layout.addWidget(self.gl_btn)
 
@@ -54,10 +66,10 @@ class SidebarWidget(QtWidgets.QWidget):
         layout.addWidget(self.gl_drop)
 
         self.gl_path_label = QtWidgets.QLabel("", self)
+        self.gl_path_label.setObjectName("PathLabel")
         self.gl_path_label.setWordWrap(True)
         layout.addWidget(self.gl_path_label)
 
-        # Sample ruter
         sample_box = QtWidgets.QGroupBox("Tilfeldig utvalg", self)
         sample_layout = QtWidgets.QFormLayout(sample_box)
         sample_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
@@ -74,19 +86,17 @@ class SidebarWidget(QtWidgets.QWidget):
 
         layout.addWidget(sample_box)
 
-        self.sample_btn = QtWidgets.QPushButton("🎲 Lag utvalg", self)
+        self.sample_btn = QtWidgets.QPushButton("Lag utvalg", self)
+        self.sample_btn.setProperty("role", "primary")
         self.sample_btn.setEnabled(False)
         self.sample_btn.clicked.connect(app.make_sample)
         layout.addWidget(self.sample_btn)
 
         self.filecount_label = QtWidgets.QLabel("Antall bilag: –", self)
+        self.filecount_label.setObjectName("PathLabel")
         layout.addWidget(self.filecount_label)
 
-        info_title = QtWidgets.QLabel("Oppdragsinfo", self)
-        info_title.setStyleSheet("font-weight: bold;")
-        layout.addWidget(info_title)
-
-        info_frame = QtWidgets.QGroupBox(self)
+        info_frame = QtWidgets.QGroupBox("Oppdragsinfo", self)
         info_layout = QtWidgets.QFormLayout(info_frame)
         info_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
         info_layout.setSpacing(style.PAD_SM)
@@ -102,13 +112,14 @@ class SidebarWidget(QtWidgets.QWidget):
 
         info_hint = QtWidgets.QLabel("Kundenavn hentes automatisk", self)
         info_hint.setWordWrap(True)
+        info_hint.setProperty("role", "muted")
         info_layout.addRow("", info_hint)
 
         layout.addWidget(info_frame)
-
         layout.addStretch(1)
 
         status_frame = QtWidgets.QGroupBox("Status", self)
+        status_frame.setObjectName("SidebarStatus")
         status_layout = QtWidgets.QVBoxLayout(status_frame)
         status_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
         status_layout.setSpacing(PADDING_Y)
@@ -133,19 +144,11 @@ class SidebarWidget(QtWidgets.QWidget):
 
         layout.addWidget(status_frame)
 
-        # Logo
-        try:
-            logo_path = resource_path("icons/borev_logo_lightmode.png")
-            pix = QtGui.QPixmap(logo_path)
-            if not pix.isNull():
-                scaled = pix.scaledToWidth(SIDEBAR_LOGO_WIDTH, QtCore.Qt.SmoothTransformation)
-                logo = QtWidgets.QLabel(self)
-                logo.setPixmap(scaled)
-                logo.setAlignment(QtCore.Qt.AlignCenter)
-                layout.addWidget(logo)
-        except Exception:  # pragma: no cover - bare logging
-            logger.exception("Kunne ikke laste sidebar-logo")
+        self.logo_label = QtWidgets.QLabel(self)
+        self.logo_label.setAlignment(QtCore.Qt.AlignCenter)
+        layout.addWidget(self.logo_label)
 
+        self._update_logo()
         self._sync_from_app()
 
     def _sync_from_app(self) -> None:
@@ -190,7 +193,6 @@ class SidebarWidget(QtWidgets.QWidget):
             self.gl_path_label.setText(valid)
             self._app._load_gl_excel()
 
-    # API for App
     def update_invoice_path(self, path: str) -> None:
         self.file_path_label.setText(path)
 
@@ -208,3 +210,18 @@ class SidebarWidget(QtWidgets.QWidget):
     def refresh_theme(self) -> None:
         self.inv_drop.refresh_theme()
         self.gl_drop.refresh_theme()
+        self._update_logo()
+
+    def _update_logo(self) -> None:
+        try:
+            logo_name = "icons/borev_logo_darkmode.png" if style.theme == "dark" else "icons/borev_logo_lightmode.png"
+            logo_path = resource_path(logo_name)
+            pix = QtGui.QPixmap(logo_path)
+            if pix.isNull():
+                self.logo_label.clear()
+                return
+            scaled = pix.scaledToWidth(SIDEBAR_LOGO_WIDTH, QtCore.Qt.SmoothTransformation)
+            self.logo_label.setPixmap(scaled)
+        except Exception:  # pragma: no cover - logging av feil
+            logger.exception("Kunne ikke laste sidebar-logo")
+            self.logo_label.clear()

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,237 +1,210 @@
-import os
+from __future__ import annotations
 
-from . import create_button
-from .style import style, PADDING_Y
-from .dropzone import DropZone
+from typing import Optional
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
 from helpers import logger
+from helpers_path import resource_path
+
+from .dropzone import DropZone
+from .style import PADDING_Y, style
 
 SIDEBAR_LOGO_WIDTH = 200
 
 
-def parse_dropped_path(event):
-    """Hent og valider filsti fra et drop-event.
-
-    Returnerer filsti dersom den peker på en Excel-fil, ellers ``None``.
-    """
-    path = event.data.strip("{}").strip()
+def parse_dropped_path(path: str) -> Optional[str]:
+    path = (path or "").strip().strip("{}")
     if not path.lower().endswith((".xlsx", ".xls")):
         return None
     return path
 
 
-def _toggle_sample_btn(app, *_):
-    state = "normal" if app.sample_size_var.get() and app.year_var.get() else "disabled"
-    app.sample_btn.configure(state=state)
+class SidebarWidget(QtWidgets.QWidget):
+    def __init__(self, app: "App"):
+        super().__init__(app)
+        self._app = app
 
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(style.PAD_XL, style.PAD_XL, style.PAD_XL, style.PAD_XL)
+        layout.setSpacing(style.PAD_MD)
 
-def build_sidebar(app):
-    import customtkinter as ctk
+        title = QtWidgets.QLabel("⚙️ Datautvalg", self)
+        title.setStyleSheet("font-weight: bold; font-size: 18px;")
+        layout.addWidget(title)
 
-    card = ctk.CTkFrame(app, corner_radius=16)
-    card.grid(row=0, column=0, sticky="nsw", padx=style.PAD_XL, pady=style.PAD_XL)
+        self.file_btn = QtWidgets.QPushButton("Velg leverandørfakturaer (Excel)…", self)
+        self.file_btn.clicked.connect(app.choose_file)
+        layout.addWidget(self.file_btn)
 
-    ctk.CTkLabel(card, text="⚙️ Datautvalg", font=style.FONT_TITLE_LARGE)\
-        .grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")
+        self.inv_drop = DropZone(self, "Dra og slipp fakturaliste her")
+        self.inv_drop.dropped.connect(self._on_invoice_drop)
+        layout.addWidget(self.inv_drop)
 
-    app.file_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
-        .grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
-    def _drop_invoice(event):
-        path = parse_dropped_path(event)
-        if not path:
-            return
-        app.file_path_var.set(path)
-        app._load_excel()
+        self.file_path_label = QtWidgets.QLabel("", self)
+        self.file_path_label.setWordWrap(True)
+        layout.addWidget(self.file_path_label)
 
-    app.inv_drop = DropZone(card, "Dra og slipp fakturaliste her", _drop_invoice)
-    app.inv_drop.grid(row=2, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
-    ctk.CTkLabel(
-        card,
-        textvariable=app.file_path_var,
-        wraplength=260,
-        anchor="w",
-        justify="left",
-        font=style.FONT_BODY,
-    ).grid(row=3, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+        self.gl_btn = QtWidgets.QPushButton("Velg hovedbok (Excel)…", self)
+        self.gl_btn.clicked.connect(app.choose_gl_file)
+        layout.addWidget(self.gl_btn)
 
-    app.gl_path_var = ctk.StringVar(master=app, value="")
-    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
-        .grid(row=4, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="ew")
+        self.gl_drop = DropZone(self, "Dra og slipp hovedbok her")
+        self.gl_drop.dropped.connect(self._on_gl_drop)
+        layout.addWidget(self.gl_drop)
 
-    def _drop_gl(event):
-        path = parse_dropped_path(event)
-        if not path:
-            return
-        app.gl_path_var.set(path)
-        app._load_gl_excel()
+        self.gl_path_label = QtWidgets.QLabel("", self)
+        self.gl_path_label.setWordWrap(True)
+        layout.addWidget(self.gl_path_label)
 
-    app.gl_drop = DropZone(card, "Dra og slipp hovedbok her", _drop_gl)
-    app.gl_drop.grid(row=5, column=0, padx=style.PAD_XL, pady=(0, style.PAD_XXS), sticky="ew")
-    ctk.CTkLabel(
-        card,
-        textvariable=app.gl_path_var,
-        wraplength=260,
-        anchor="w",
-        justify="left",
-        font=style.FONT_BODY,
-    ).grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
+        # Sample ruter
+        sample_box = QtWidgets.QGroupBox("Tilfeldig utvalg", self)
+        sample_layout = QtWidgets.QFormLayout(sample_box)
+        sample_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
+        sample_layout.setSpacing(style.PAD_SM)
 
-    app.add_drop_target(app.inv_drop, app.inv_drop.on_drop)
-    app.add_drop_target(app.gl_drop, app.gl_drop.on_drop)
+        self.sample_size_edit = QtWidgets.QLineEdit(self)
+        self.sample_size_edit.setValidator(QtGui.QIntValidator(0, 999999, self))
+        self.sample_size_edit.textChanged.connect(self._toggle_sample_btn)
+        sample_layout.addRow("Antall", self.sample_size_edit)
 
-    row_utv = ctk.CTkFrame(card)
-    row_utv.grid(row=7, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, 0), sticky="ew")
-    ctk.CTkLabel(row_utv, text="Antall tilfeldig utvalg", font=style.FONT_BODY).grid(
-        row=0, column=0, padx=(style.PAD_MD, 0), sticky="w"
-    )
+        self.year_combo = QtWidgets.QComboBox(self)
+        self.year_combo.currentTextChanged.connect(self._toggle_sample_btn)
+        sample_layout.addRow("År", self.year_combo)
 
-    def _validate_int(P: str) -> bool:
-        return P.isdigit() or P == ""
+        layout.addWidget(sample_box)
 
-    vcmd_int = app.register(_validate_int)
-    app.sample_size_var = ctk.StringVar(master=app, value="")
-    ctk.CTkEntry(
-        row_utv,
-        width=80,
-        textvariable=app.sample_size_var,
-        validate="key",
-        validatecommand=(vcmd_int, "%P"),
-    ).grid(row=0, column=1, padx=(style.PAD_MD, 0))
+        self.sample_btn = QtWidgets.QPushButton("🎲 Lag utvalg", self)
+        self.sample_btn.setEnabled(False)
+        self.sample_btn.clicked.connect(app.make_sample)
+        layout.addWidget(self.sample_btn)
 
-    ctk.CTkLabel(row_utv, text="År", font=style.FONT_BODY).grid(
-        row=1,
-        column=0,
-        padx=(style.PAD_MD, 0),
-        pady=(style.PAD_SM, 0),
-        sticky="w",
-    )
+        self.filecount_label = QtWidgets.QLabel("Antall bilag: –", self)
+        layout.addWidget(self.filecount_label)
 
-    app.year_var = ctk.StringVar(master=app, value="")
-    app.year_combo = ctk.CTkComboBox(
-        row_utv,
-        width=80,
-        variable=app.year_var,
-        values=[],
-        state="readonly",
-        command=lambda _: _toggle_sample_btn(app),
-    )
-    app.year_combo.grid(row=1, column=1, padx=(style.PAD_MD, 0), pady=(style.PAD_SM, 0))
+        info_title = QtWidgets.QLabel("Oppdragsinfo", self)
+        info_title.setStyleSheet("font-weight: bold;")
+        layout.addWidget(info_title)
 
-    app.sample_btn = create_button(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
-    app.sample_btn.grid(row=8, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_SM), sticky="ew")
+        info_frame = QtWidgets.QGroupBox(self)
+        info_layout = QtWidgets.QFormLayout(info_frame)
+        info_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
+        info_layout.setSpacing(style.PAD_SM)
 
-    app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
-    app._update_year_options()
+        self.kunde_edit = QtWidgets.QLineEdit(self)
+        self.kunde_edit.setPlaceholderText("Hentes automatisk")
+        self.kunde_edit.setEnabled(False)
+        info_layout.addRow("Kunde", self.kunde_edit)
 
-    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=style.FONT_TITLE)
-    app.lbl_filecount.grid(row=9, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XXS), sticky="w")
+        self.utfort_av_edit = QtWidgets.QLineEdit(self)
+        self.utfort_av_edit.textChanged.connect(lambda text: app.utfort_av_var.set(text))
+        info_layout.addRow("Utført av", self.utfort_av_edit)
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.FONT_BODY_BOLD)\
-        .grid(row=10, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XXS), sticky="w")
-    opp = ctk.CTkFrame(card, corner_radius=8)
-    opp.grid(row=11, column=0, padx=style.PAD_XL, pady=(0, style.PAD_MD), sticky="ew")
-    opp.grid_columnconfigure(0, weight=0)
-    opp.grid_columnconfigure(1, weight=1)
+        info_hint = QtWidgets.QLabel("Kundenavn hentes automatisk", self)
+        info_hint.setWordWrap(True)
+        info_layout.addRow("", info_hint)
 
-    app.kunde_var = ctk.StringVar(master=app, value="")
-    default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
-    app.utfort_av_var = ctk.StringVar(master=app, value=default_user)
+        layout.addWidget(info_frame)
 
-    ctk.CTkLabel(opp, text="Kunde", font=style.FONT_BODY).grid(
-        row=0,
-        column=0,
-        padx=(style.PAD_MD, style.PAD_MD),
-        pady=(style.PAD_MD, style.PAD_XS),
-        sticky="w",
-    )
-    app.kunde_entry = ctk.CTkEntry(
-        opp,
-        textvariable=app.kunde_var,
-        placeholder_text="Hentes automatisk",
-        state="disabled",
-    )
-    app.kunde_entry.grid(row=0, column=1, padx=(0, style.PAD_MD), pady=(style.PAD_MD, style.PAD_XS), sticky="ew")
-    ctk.CTkLabel(opp, text="Utført av", font=style.FONT_BODY).grid(
-        row=1,
-        column=0,
-        padx=(style.PAD_MD, style.PAD_MD),
-        pady=(style.PAD_XS, style.PAD_MD),
-        sticky="w",
-    )
-    ctk.CTkEntry(opp, textvariable=app.utfort_av_var).grid(row=1, column=1, padx=(0, style.PAD_MD), pady=(style.PAD_XS, style.PAD_MD), sticky="ew")
-    info_lbl = ctk.CTkLabel(
-        opp,
-        text="Kundenavn hentes automatisk",
-        font=style.FONT_SMALL_ITALIC,
-        anchor="w",
-        justify="left",
-        wraplength=240,
-    )
-    info_lbl.grid(row=2, column=0, columnspan=2, padx=(style.PAD_MD, style.PAD_MD), pady=(0, style.PAD_MD), sticky="w")
+        layout.addStretch(1)
 
-    card.grid_rowconfigure(20, weight=1)
+        status_frame = QtWidgets.QGroupBox("Status", self)
+        status_layout = QtWidgets.QVBoxLayout(status_frame)
+        status_layout.setContentsMargins(style.PAD_MD, style.PAD_MD, style.PAD_MD, style.PAD_MD)
+        status_layout.setSpacing(PADDING_Y)
 
-    status_card = ctk.CTkFrame(card, corner_radius=12)
-    status_card.grid(
-        row=100,
-        column=0,
-        padx=style.PAD_XL,
-        pady=(style.PAD_MD, PADDING_Y),
-        sticky="ew",
-    )
-    status_card.grid_columnconfigure(0, weight=1)
+        self.lbl_st_sum_kontrollert = QtWidgets.QLabel("Sum kontrollert: –", self)
+        self.lbl_st_sum_alle = QtWidgets.QLabel("Sum alle bilag: –", self)
+        self.lbl_st_pct = QtWidgets.QLabel("% kontrollert av sum: –", self)
+        self.lbl_st_godkjent = QtWidgets.QLabel("Godkjent: –", self)
+        self.lbl_st_ikkegodkjent = QtWidgets.QLabel("Ikke godkjent: –", self)
+        self.lbl_st_gjen = QtWidgets.QLabel("Gjenstår å kontrollere: –", self)
 
-    title_font = style.FONT_TITLE_LARGE
-    body_font = style.FONT_BODY
+        for lbl in (
+            self.lbl_st_sum_kontrollert,
+            self.lbl_st_sum_alle,
+            self.lbl_st_pct,
+            self.lbl_st_godkjent,
+            self.lbl_st_ikkegodkjent,
+            self.lbl_st_gjen,
+        ):
+            lbl.setAlignment(QtCore.Qt.AlignCenter)
+            status_layout.addWidget(lbl)
 
-    ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
-        .grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
+        layout.addWidget(status_frame)
 
-    app.lbl_st_sum_kontrollert = ctk.CTkLabel(status_card, text="Sum kontrollert: –", font=body_font, anchor="center", justify="center")
-    app.lbl_st_sum_kontrollert.grid(row=1, column=0, sticky="ew", pady=(0, style.PAD_XXS))
+        # Logo
+        try:
+            logo_path = resource_path("icons/borev_logo_lightmode.png")
+            pix = QtGui.QPixmap(logo_path)
+            if not pix.isNull():
+                scaled = pix.scaledToWidth(SIDEBAR_LOGO_WIDTH, QtCore.Qt.SmoothTransformation)
+                logo = QtWidgets.QLabel(self)
+                logo.setPixmap(scaled)
+                logo.setAlignment(QtCore.Qt.AlignCenter)
+                layout.addWidget(logo)
+        except Exception:  # pragma: no cover - bare logging
+            logger.exception("Kunne ikke laste sidebar-logo")
 
-    app.lbl_st_sum_alle = ctk.CTkLabel(status_card, text="Sum alle bilag: –", font=body_font, anchor="center", justify="center")
-    app.lbl_st_sum_alle.grid(row=2, column=0, sticky="ew", pady=(0, style.PAD_XXS))
+        self._sync_from_app()
 
-    app.lbl_st_pct = ctk.CTkLabel(status_card, text="% kontrollert av sum: –", font=body_font, anchor="center", justify="center")
-    app.lbl_st_pct.grid(row=3, column=0, sticky="ew", pady=(0, style.PAD_MD))
+    def _sync_from_app(self) -> None:
+        app = self._app
+        self.file_path_label.setText(app.file_path_var.get())
+        self.gl_path_label.setText(app.gl_path_var.get())
+        self.sample_size_edit.setText(app.sample_size_var.get())
+        self.year_combo.setCurrentText(app.year_var.get())
+        self.kunde_edit.setText(app.kunde_var.get())
+        self.utfort_av_edit.setText(app.utfort_av_var.get())
+        app.lbl_st_sum_kontrollert = self.lbl_st_sum_kontrollert
+        app.lbl_st_sum_alle = self.lbl_st_sum_alle
+        app.lbl_st_pct = self.lbl_st_pct
+        app.lbl_st_godkjent = self.lbl_st_godkjent
+        app.lbl_st_ikkegodkjent = self.lbl_st_ikkegodkjent
+        app.lbl_st_gjen = self.lbl_st_gjen
+        app.sample_btn = self.sample_btn
+        app.year_combo = self.year_combo
+        app.kunde_entry = self.kunde_edit
+        app.utfort_av_edit = self.utfort_av_edit
+        app.lbl_filecount = self.filecount_label
 
-    app.lbl_st_godkjent = ctk.CTkLabel(status_card, text="Godkjent: –", font=body_font, anchor="center", justify="center")
-    app.lbl_st_godkjent.grid(row=4, column=0, sticky="ew", pady=(0, style.PAD_XXS))
+    def _toggle_sample_btn(self) -> None:
+        text = self.sample_size_edit.text().strip()
+        year = self.year_combo.currentText().strip()
+        enabled = bool(text) and bool(year)
+        self.sample_btn.setEnabled(enabled)
+        self._app.sample_size_var.set(text)
+        self._app.year_var.set(year)
 
-    app.lbl_st_ikkegodkjent = ctk.CTkLabel(status_card, text="Ikke godkjent: –", font=body_font, anchor="center", justify="center")
-    app.lbl_st_ikkegodkjent.grid(row=5, column=0, sticky="ew", pady=(0, style.PAD_XXS))
+    def _on_invoice_drop(self, path: str) -> None:
+        valid = parse_dropped_path(path)
+        if valid:
+            self._app.file_path_var.set(valid)
+            self.file_path_label.setText(valid)
+            self._app._load_excel()
 
-    app.lbl_st_gjen = ctk.CTkLabel(status_card, text="Gjenstår å kontrollere: –", font=body_font, anchor="center", justify="center")
-    app.lbl_st_gjen.grid(row=6, column=0, sticky="ew", pady=(style.PAD_SM, PADDING_Y))
+    def _on_gl_drop(self, path: str) -> None:
+        valid = parse_dropped_path(path)
+        if valid:
+            self._app.gl_path_var.set(valid)
+            self.gl_path_label.setText(valid)
+            self._app._load_gl_excel()
 
-    try:
-        from PIL import Image
-        from helpers_path import resource_path
+    # API for App
+    def update_invoice_path(self, path: str) -> None:
+        self.file_path_label.setText(path)
 
-        img_light = Image.open(resource_path("icons/borev_logo_lightmode.png"))
-        img_dark = Image.open(resource_path("icons/borev_logo_darkmode.png"))
+    def update_gl_path(self, path: str) -> None:
+        self.gl_path_label.setText(path)
 
-        w, h = img_light.size
-        scaled_h = int(h * (SIDEBAR_LOGO_WIDTH / w))
-        app.sidebar_logo_img = ctk.CTkImage(
-            light_image=img_light,
-            dark_image=img_dark,
-            size=(SIDEBAR_LOGO_WIDTH, scaled_h),
-        )
-        ctk.CTkLabel(
-            card,
-            text="",
-            image=app.sidebar_logo_img,
-            font=style.FONT_BODY,
-        ).grid(
-            row=101,
-            column=0,
-            padx=style.PAD_XL,
-            pady=(0, PADDING_Y),
-            sticky="ew",
-        )
-    except (ImportError, OSError):
-        logger.exception("Kunne ikke laste sidebar-logo")
+    def set_year_options(self, options: list[str]) -> None:
+        self.year_combo.blockSignals(True)
+        self.year_combo.clear()
+        self.year_combo.addItems(options)
+        self.year_combo.blockSignals(False)
+        if options:
+            self.year_combo.setCurrentIndex(0)
 
-    return card
+    def refresh_theme(self) -> None:
+        self.inv_drop.refresh_theme()
+        self.gl_drop.refresh_theme()

--- a/gui/style.py
+++ b/gui/style.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Dict
 
 
 # Standard padding for GUI-komponenter
-PADDING_X = 10
-PADDING_Y = 8
+PADDING_X = 12
+PADDING_Y = 10
 
 
 @dataclass
@@ -12,9 +14,7 @@ class Style:
     """Samler felles stilkonfigurasjon for GUI."""
 
     # Knappestil
-    BTN_FG: str = "#1f6aa5"
-    BTN_HOVER: str = "#185a8b"
-    BTN_RADIUS: int = 8
+    BTN_RADIUS: int = 10
 
     theme: str = "light"
 
@@ -28,6 +28,10 @@ class Style:
             # Generelle farger
             "bg": {"light": "#ffffff", "dark": "#1e1e1e"},
             "fg": {"light": "#000000", "dark": "#e6e6e6"},
+            "text_muted": {"light": "#6b7280", "dark": "#9ca3b0"},
+            "accent": {"light": "#2563eb", "dark": "#4f8bff"},
+            "accent_hover": {"light": "#1d4ed8", "dark": "#3a7cff"},
+            "muted": {"light": "#e2e8f0", "dark": "#2d3340"},
             # Dra-og-slipp felt
             "dnd_bg": {"light": "#f5f6f7", "dark": "#2b2b2b"},
             "dnd_border": {"light": "#a8b1bb", "dark": "#4a4f55"},
@@ -39,11 +43,26 @@ class Style:
             "table_sel_fg": {"light": "#000000", "dark": "#ffffff"},
             "table_row_odd": {"light": "#f6f6f6", "dark": "#232323"},
             "table_row_even": {"light": "#ffffff", "dark": "#1e1e1e"},
+            # Overflater
+            "panel_bg": {"light": "#ffffff", "dark": "#1b1d24"},
+            "panel_border": {"light": "#d5dae3", "dark": "#2a2e38"},
+            "sidebar_bg": {"light": "#f3f5fa", "dark": "#12141a"},
+            "header_bg": {"light": "#1f2937", "dark": "#0f172a"},
+            "header_bg_alt": {"light": "#111827", "dark": "#172554"},
+            "header_fg": {"light": "#f9fafb", "dark": "#e2e8f0"},
+            "button_bg": {"light": "#eef2f7", "dark": "#2a2f3a"},
+            "button_fg": {"light": "#1f2933", "dark": "#e5e7eb"},
+            "button_hover": {"light": "#e0e7ef", "dark": "#363c49"},
+            "outline": {"light": "#cbd5f5", "dark": "#334155"},
+            "badge_bg": {"light": "#1f2937", "dark": "#1e40af"},
+            "progress_bg": {"light": "#e5e7eb", "dark": "#2a2f3a"},
+            "progress_chunk": {"light": "#2563eb", "dark": "#4f8bff"},
         }
     )
 
     # Skrifttyper
-    FONT_FAMILY: str = "Helvetica"
+    FONT_FAMILY: str = "'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    BASE_FONT_SIZE: int = 14
 
     # Standard spacing
     PAD_XL: int = 14
@@ -52,6 +71,7 @@ class Style:
     PAD_SM: int = 6
     PAD_XS: int = 4
     PAD_XXS: int = 2
+    CARD_RADIUS: int = 14
 
     def set_theme(self, mode: str) -> None:
         mode = (mode or "").strip().lower()
@@ -89,3 +109,265 @@ def apply_palette(app) -> None:
     palette.setColor(palette.Highlight, QtGui.QColor(style.get_color("table_sel_bg")))
     palette.setColor(palette.HighlightedText, QtGui.QColor(style.get_color("table_sel_fg")))
     app.setPalette(palette)
+
+
+def build_stylesheet() -> str:
+    """Lag en global Qt-stylesheet basert på valgt tema."""
+
+    accent = style.get_color("accent")
+    accent_hover = style.get_color("accent_hover")
+    danger = style.get_color("error")
+    danger_hover = style.get_color("error_hover")
+    text_muted = style.get_color("text_muted")
+    panel_bg = style.get_color("panel_bg")
+    border = style.get_color("panel_border")
+    header_bg = style.get_color("header_bg")
+    header_bg_alt = style.get_color("header_bg_alt")
+    header_fg = style.get_color("header_fg")
+    button_bg = style.get_color("button_bg")
+    button_fg = style.get_color("button_fg")
+    button_hover = style.get_color("button_hover")
+    progress_bg = style.get_color("progress_bg")
+    progress_chunk = style.get_color("progress_chunk")
+    outline = style.get_color("outline")
+
+    pad_sm = style.PAD_SM
+    pad_md = style.PAD_MD
+    pad_lg = style.PAD_LG
+    pad_xs = style.PAD_XS
+    card_radius = style.CARD_RADIUS
+    btn_radius = style.BTN_RADIUS
+    font = style.FONT_FAMILY
+    base_size = style.BASE_FONT_SIZE
+
+    return f"""
+    QWidget {{
+        font-family: {font};
+        font-size: {base_size}px;
+        color: {style.get_color('fg')};
+        background-color: {style.get_color('bg')};
+    }}
+
+    QMainWindow {{
+        background-color: {style.get_color('bg')};
+    }}
+
+    QLabel[role="muted"] {{
+        color: {text_muted};
+    }}
+
+    QFrame#HeaderFrame {{
+        background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 {header_bg}, stop:1 {header_bg_alt});
+        border-radius: {card_radius}px;
+        padding: 0;
+    }}
+
+    QFrame#HeaderFrame QLabel {{
+        color: {header_fg};
+    }}
+
+    QLabel#HeaderTitle {{
+        font-size: 26px;
+        font-weight: 600;
+    }}
+
+    QLabel#HeaderSubtitle {{
+        font-size: 13px;
+        color: {header_fg}cc;
+    }}
+
+    QFrame[role="card"] {{
+        background-color: {panel_bg};
+        border-radius: {card_radius}px;
+        border: 1px solid {border};
+    }}
+
+    QFrame[role="card"] QLabel[role="caption"] {{
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 11px;
+        color: {text_muted};
+    }}
+
+    QFrame[role="card"] QLabel[role="value"] {{
+        font-size: 20px;
+        font-weight: 600;
+    }}
+
+    QLabel#InlineStatus, QLabel#InlineFeedback {{
+        font-size: 12px;
+        color: {text_muted};
+    }}
+
+    QFrame#Sidebar {{
+        background-color: {style.get_color('sidebar_bg')};
+        border-top-right-radius: {card_radius}px;
+        border-bottom-right-radius: {card_radius}px;
+        border: 1px solid {border};
+    }}
+
+    QLabel#SidebarTitle {{
+        font-size: 18px;
+        font-weight: 600;
+    }}
+
+    QLabel#SidebarDescription {{
+        color: {text_muted};
+        font-size: 12px;
+    }}
+
+    QLabel#PathLabel {{
+        color: {text_muted};
+        font-size: 12px;
+    }}
+
+    QGroupBox {{
+        border: 1px solid {border};
+        border-radius: {card_radius}px;
+        margin-top: {pad_md}px;
+        background-color: {panel_bg};
+    }}
+
+    QGroupBox::title {{
+        subcontrol-origin: margin;
+        left: {pad_md}px;
+        padding: 0 {pad_md}px;
+        text-transform: uppercase;
+        font-size: 12px;
+        letter-spacing: 0.12em;
+        color: {text_muted};
+    }}
+
+    QPushButton {{
+        border: none;
+        border-radius: {btn_radius}px;
+        padding: {pad_sm + 2}px {pad_lg + 2}px;
+        background-color: {button_bg};
+        color: {button_fg};
+        font-weight: 500;
+    }}
+
+    QPushButton:hover {{
+        background-color: {button_hover};
+    }}
+
+    QPushButton:disabled {{
+        background-color: {button_bg};
+        color: {text_muted};
+    }}
+
+    QPushButton[role="primary"] {{
+        background-color: {accent};
+        color: #ffffff;
+        font-weight: 600;
+    }}
+
+    QPushButton[role="primary"]:hover {{
+        background-color: {accent_hover};
+    }}
+
+    QPushButton[role="danger"] {{
+        background-color: {danger};
+        color: #ffffff;
+    }}
+
+    QPushButton[role="danger"]:hover {{
+        background-color: {danger_hover};
+    }}
+
+    QPushButton[role="ghost"] {{
+        background-color: transparent;
+        border: 1px solid {border};
+    }}
+
+    QPushButton[role="ghost"]:hover {{
+        background-color: {button_hover};
+    }}
+
+    QPushButton[role="secondary"] {{
+        background-color: {button_bg};
+        color: {button_fg};
+        border: 1px solid transparent;
+    }}
+
+    QPushButton[role="secondary"]:hover {{
+        border: 1px solid {border};
+    }}
+
+    QToolButton[role="icon"] {{
+        border: none;
+        border-radius: {btn_radius}px;
+        padding: {pad_xs}px;
+        background: transparent;
+    }}
+
+    QToolButton[role="icon"]:hover {{
+        background-color: {button_hover};
+        color: {accent};
+    }}
+
+    QPlainTextEdit {{
+        border: 1px solid {border};
+        border-radius: {card_radius}px;
+        padding: {pad_md}px;
+        background-color: {panel_bg};
+    }}
+
+    QTableWidget {{
+        background-color: {panel_bg};
+        border: 1px solid {border};
+        border-radius: {card_radius}px;
+        gridline-color: {border};
+    }}
+
+    QHeaderView::section {{
+        background-color: {button_bg};
+        color: {button_fg};
+        padding: {pad_sm}px {pad_md}px;
+        border: none;
+        font-weight: 600;
+    }}
+
+    QTableWidget::item:selected {{
+        background-color: {style.get_color('table_sel_bg')};
+        color: {style.get_color('table_sel_fg')};
+    }}
+
+    QProgressBar {{
+        border: 1px solid {border};
+        border-radius: {btn_radius}px;
+        background-color: {progress_bg};
+        padding: 0;
+        text-align: center;
+    }}
+
+    QProgressBar::chunk {{
+        border-radius: {btn_radius}px;
+        background-color: {progress_chunk};
+    }}
+
+    QDialog#BusyDialog {{
+        background-color: {panel_bg};
+        border-radius: {card_radius}px;
+    }}
+
+    QSplitter::handle {{
+        background-color: {outline};
+        margin: 0 {pad_xs}px;
+        width: 2px;
+    }}
+
+    QSplitter::handle:pressed {{
+        background-color: {accent};
+    }}
+
+    QLabel#StatusLabel {{
+        color: {text_muted};
+    }}
+    """
+
+
+def apply_stylesheet(app) -> None:
+    """Påfør stylesheet basert på aktivt tema."""
+
+    app.setStyleSheet(build_stylesheet())

--- a/gui/style.py
+++ b/gui/style.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple
+from typing import Dict
 
 
 # Standard padding for GUI-komponenter
@@ -15,6 +15,8 @@ class Style:
     BTN_FG: str = "#1f6aa5"
     BTN_HOVER: str = "#185a8b"
     BTN_RADIUS: int = 8
+
+    theme: str = "light"
 
     # Farger per tema
     COLORS: Dict[str, Dict[str, str]] = field(
@@ -40,35 +42,8 @@ class Style:
         }
     )
 
-    def get_color(self, name: str) -> str:
-        """Returner farge tilpasset valgt tema."""
-        import customtkinter as ctk
-
-        mode = ctk.get_appearance_mode().lower()
-        try:
-            return self.COLORS[name]["dark" if mode == "dark" else "light"]
-        except KeyError as e:
-            raise KeyError(f"Ukjent fargenavn: {name}") from e
-
-    def get_color_pair(self, name: str) -> Tuple[str, str]:
-        """Returner (lys, mørk) fargepar for CustomTkinter-komponenter."""
-        try:
-            col = self.COLORS[name]
-            return col["light"], col["dark"]
-        except KeyError as e:
-            raise KeyError(f"Ukjent fargenavn: {name}") from e
-
     # Skrifttyper
     FONT_FAMILY: str = "Helvetica"
-    # Skrifttyper (initialiseres lazily)
-    FONT_TITLE: Optional[object] = None
-    FONT_BODY: Optional[object] = None
-    FONT_TITLE_LITE: Optional[object] = None
-    FONT_TITLE_LARGE: Optional[object] = None
-    FONT_TITLE_SMALL: Optional[object] = None
-    FONT_BODY_BOLD: Optional[object] = None
-    FONT_SMALL: Optional[object] = None
-    FONT_SMALL_ITALIC: Optional[object] = None
 
     # Standard spacing
     PAD_XL: int = 14
@@ -78,5 +53,39 @@ class Style:
     PAD_XS: int = 4
     PAD_XXS: int = 2
 
+    def set_theme(self, mode: str) -> None:
+        mode = (mode or "").strip().lower()
+        if mode not in {"light", "dark"}:
+            mode = "light"
+        self.theme = mode
+
+    def get_color(self, name: str) -> str:
+        try:
+            return self.COLORS[name]["dark" if self.theme == "dark" else "light"]
+        except KeyError as exc:
+            raise KeyError(f"Ukjent fargenavn: {name}") from exc
+
 
 style = Style()
+
+
+def apply_palette(app) -> None:
+    """Oppdater Qt-paletten basert på valgt tema."""
+
+    from PyQt5 import QtGui
+
+    palette = app.palette()
+    bg = QtGui.QColor(style.get_color("bg"))
+    fg = QtGui.QColor(style.get_color("fg"))
+    palette.setColor(palette.Window, bg)
+    palette.setColor(palette.WindowText, fg)
+    palette.setColor(palette.Base, bg)
+    palette.setColor(palette.AlternateBase, QtGui.QColor(style.get_color("table_row_odd")))
+    palette.setColor(palette.ToolTipBase, bg)
+    palette.setColor(palette.ToolTipText, fg)
+    palette.setColor(palette.Text, fg)
+    palette.setColor(palette.Button, bg)
+    palette.setColor(palette.ButtonText, fg)
+    palette.setColor(palette.Highlight, QtGui.QColor(style.get_color("table_sel_bg")))
+    palette.setColor(palette.HighlightedText, QtGui.QColor(style.get_color("table_sel_fg")))
+    app.setPalette(palette)


### PR DESCRIPTION
## Sammendrag
- erstatt CustomTkinter-baserte komponenter med en komplett PyQt5-implementasjon av hovedvindu, sidebar og hovedpanel
- legg til Qt-spesifikke hjelpeklasser for dra-og-slipp, tabeller og tekstbokser samt moderniser farge- og temaoppsettet
- oppdater bakgrunnslogikk for lasting av Excel og hovedbok til å bruke Qt-tråder og statusvisning samtidig som eksisterende rapportfunksjoner beholdes

## Testing
- pytest *(feiler: mangler pandas/openpyxl i miljøet)*

------
https://chatgpt.com/codex/tasks/task_e_68ffd8b50ed48328a820d8fb071d5eec