### PR TITLE
Legg til antall bilag i PDF, formater «Utført av» og gjør oppstart raskere

### DIFF
--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from . import create_button
 from .style import style, PADDING_Y
@@ -22,6 +23,51 @@ def parse_dropped_path(event):
 def _toggle_sample_btn(app, *_):
     state = "normal" if app.sample_size_var.get() and app.year_var.get() else "disabled"
     app.sample_btn.configure(state=state)
+
+
+def _format_user_name(raw_name: str) -> str:
+    """Gjør brukernavn mer lesbart, f.eks. ``MadsKristensen`` -> ``Mads Kristensen``."""
+    text = (raw_name or "").strip()
+    if not text:
+        return ""
+
+    text = re.sub(r"[._-]+", " ", text)
+    text = re.sub(r"([a-zæøå])([A-ZÆØÅ])", r"\1 \2", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text.title()
+
+
+def _load_sidebar_logo(app, card):
+    import customtkinter as ctk
+
+    try:
+        from PIL import Image
+        from helpers_path import resource_path
+
+        img_light = Image.open(resource_path("icons/borev_logo_lightmode.png"))
+        img_dark = Image.open(resource_path("icons/borev_logo_darkmode.png"))
+
+        w, h = img_light.size
+        scaled_h = int(h * (SIDEBAR_LOGO_WIDTH / w))
+        app.sidebar_logo_img = ctk.CTkImage(
+            light_image=img_light,
+            dark_image=img_dark,
+            size=(SIDEBAR_LOGO_WIDTH, scaled_h),
+        )
+        ctk.CTkLabel(
+            card,
+            text="",
+            image=app.sidebar_logo_img,
+            font=style.FONT_BODY,
+        ).grid(
+            row=101,
+            column=0,
+            padx=style.PAD_XL,
+            pady=(0, PADDING_Y),
+            sticky="ew",
+        )
+    except (ImportError, OSError):
+        logger.exception("Kunne ikke laste sidebar-logo")
 
 
 def build_sidebar(app):
@@ -134,7 +180,9 @@ def build_sidebar(app):
     opp.grid_columnconfigure(1, weight=1)
 
     app.kunde_var = ctk.StringVar(master=app, value="")
-    default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+    default_user = _format_user_name(
+        os.environ.get("USERNAME") or os.environ.get("USER") or ""
+    )
     app.utfort_av_var = ctk.StringVar(master=app, value=default_user)
 
     ctk.CTkLabel(opp, text="Kunde", font=style.FONT_BODY).grid(
@@ -205,33 +253,6 @@ def build_sidebar(app):
     app.lbl_st_gjen = ctk.CTkLabel(status_card, text="Gjenstår å kontrollere: –", font=body_font, anchor="center", justify="center")
     app.lbl_st_gjen.grid(row=6, column=0, sticky="ew", pady=(style.PAD_SM, PADDING_Y))
 
-    try:
-        from PIL import Image
-        from helpers_path import resource_path
-
-        img_light = Image.open(resource_path("icons/borev_logo_lightmode.png"))
-        img_dark = Image.open(resource_path("icons/borev_logo_darkmode.png"))
-
-        w, h = img_light.size
-        scaled_h = int(h * (SIDEBAR_LOGO_WIDTH / w))
-        app.sidebar_logo_img = ctk.CTkImage(
-            light_image=img_light,
-            dark_image=img_dark,
-            size=(SIDEBAR_LOGO_WIDTH, scaled_h),
-        )
-        ctk.CTkLabel(
-            card,
-            text="",
-            image=app.sidebar_logo_img,
-            font=style.FONT_BODY,
-        ).grid(
-            row=101,
-            column=0,
-            padx=style.PAD_XL,
-            pady=(0, PADDING_Y),
-            sticky="ew",
-        )
-    except (ImportError, OSError):
-        logger.exception("Kunne ikke laste sidebar-logo")
+    app.after(10, lambda: _load_sidebar_logo(app, card))
 
     return card

--- a/report.py
+++ b/report.py
@@ -67,6 +67,7 @@ def create_info_table(app, now):
 
 
 def create_status_table(app, body):
+    total_bilag = len(app.sample_df.index)
     approved = sum(1 for d in app.decisions if d == "Godkjent")
     rejected = sum(1 for d in app.decisions if d == "Ikke godkjent")
     remaining = sum(1 for d in app.decisions if d is None)
@@ -93,6 +94,7 @@ def create_status_table(app, body):
         Paragraph(
             (
                 "<b>Status</b>:<br/>"
+                f"Antall bilag: {total_bilag}<br/>"
                 f"Sum kontrollert: {fmt_money(sum_k)} kr<br/>"
                 f"Sum alle bilag: {fmt_money(sum_a)} kr<br/>"
                 f"% kontrollert: {fmt_pct(pct)}"
@@ -275,4 +277,3 @@ def export_pdf(app):
         app._show_inline(f"Feil ved PDF-generering: {e}", ok=False)
     finally:
         app._set_status("")
-


### PR DESCRIPTION
### Motivation
- Gi mer informativ PDF-rapport ved å vise antall bilag i statusseksjonen. 
- Gjøre standardverdien i feltet `Utført av` mer lesbar ved å sette inn mellomrom mellom fornavn og etternavn automatisk. 
- Redusere opplevd oppstartstid ved å utsette kostbar bildebehandling til UI er vist.

### Description
- La til `total_bilag = len(app.sample_df.index)` og viser `Antall bilag` i status-teksten i `create_status_table` i `report.py` slik at PDF-rapporten nå inkluderer antall bilag. 
- Legg til `_format_user_name(raw_name: str)` i `gui/sidebar.py` som normaliserer brukernavn (fjerner `_ . -`, splitter sammensatte navn ved store bokstaver og gjør tittelkasing), og bruk denne når `default_user` settes for `app.utfort_av_var` (eksempel: `MadsKristensen` → `Mads Kristensen`). 
- Trekk ut logo-lasting til `_load_sidebar_logo(app, card)` og kall den asynkront med `app.after(10, lambda: _load_sidebar_logo(app, card))` i `gui/sidebar.py` for å unngå at bildeinnlasting blokkerer GUI-initialisering. 
- Mindre import- og layoutendringer: la til `import re` i `gui/sidebar.py` og ryddet bort synkrone bilde-load-blokker.

### Testing
- Kjørte `pytest -q tests/test_status_card.py tests/test_ledger_message.py`, resultat: `2 passed`. 
- Kjørte full test-suite med `pytest -q`, resultat: `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb100e1c3c8328b9354c7ef7d818b2)